### PR TITLE
Fix rubygems description and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added <!-- for new features. -->
+### Changed <!-- for changes in existing functionality. -->
+### Deprecated <!-- for soon-to-be removed features. -->
+### Removed <!-- for now removed features. -->
+### Fixed <!-- for any bug fixes. -->
+
+## [0.1.1] - 2021-08-19
+### Added
+- This CHANGELOG file!
+### Fixed
+- Fix the gemspec description, which had previously been written in rdoc format (causing it to
+  appear garbled on rubygems.org).
+
+## [0.1.0] - 2021-08-18
+### Added
+- Initial release! This repo is the result of some merging, squashing, and commit massaging, in
+  preparation for a public release! The goal was to maintain historical commit authorship of the
+  ancestor repos (`delayed_job` and `delayed_job_active_record`), plus the changes from Betterment's
+  internal forks.
+
+[0.1.1]: https://github.com/betterment/delayed/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/betterment/delayed/releases/tag/v0.1.0

--- a/delayed.gemspec
+++ b/delayed.gemspec
@@ -2,18 +2,12 @@ Gem::Specification.new do |spec|
   spec.authors        = ['Nathan Griffith', 'Rowan McDonald', 'Cyrus Eslami', 'John Mileham', 'Brandon Keepers', 'Brian Ryckbost',
                          'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']
   spec.description    = <<~MSG
-    ===== +Delayed+ is a multi-threaded, SQL-driven ActiveJob backend used at {Betterment}[https://betterment.com] to process millions of background jobs per day.
-
-    It supports *postgres*, *mysql*, and *sqlite*, and is designed to be:
-
-    - *Reliable*, with co-transactional job enqueues and guaranteed, at-least-once execution
-    - *Scalable*, with an optimized pickup query and concurrent job execution
-    - *Resilient*, with built-in retry mechanisms, exponential backoff, and failed job preservation
-    - *Maintainable*, with robust instrumentation, continuous monitoring, and priority-based alerting
-
-    For an overview of how Betterment uses +delayed+ to build resilience into distributed systems, check
-    out the talk ✨{Can I break this?}[https://www.youtube.com/watch?v=TuhS13rBoVY]✨ given at RailsConf
-    2021!
+    Delayed is a multi-threaded, SQL-driven ActiveJob backend used at Betterment to process millions
+    of background jobs per day. It supports postgres, mysql, and sqlite, and is designed to be
+    Reliable (with co-transactional job enqueues and guaranteed, at-least-once execution), Scalable
+    (with an optimized pickup query and concurrent job execution), Resilient (with built-in retry
+    mechanisms, exponential backoff, and failed job preservation), and Maintainable (with robust
+    instrumentation, continuous monitoring, and priority-based alerting).
   MSG
   spec.email          = ['nathan@betterment.com']
   spec.files          = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.md']
@@ -24,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
   spec.summary        = 'a multi-threaded, SQL-driven ActiveJob backend used at Betterment to process millions of background jobs per day'
 
-  spec.version        = '0.1.0'
+  spec.version        = '0.1.1'
   spec.metadata       = {
     'changelog_uri' => 'https://github.com/betterment/delayed/blob/main/CHANGELOG.md',
     'bug_tracker_uri' => 'https://github.com/betterment/delayed/issues',


### PR DESCRIPTION
/domain @samandmoore @effron 
/no-platform

This fixes the gemspec description, which had previously been written in rdoc format (causing it to appear garbled on rubygems.org). It also adds a CHANGELOG and bumps the version to `0.1.1`.