### PR TITLE
Support Ruby 3.0 kwarg-handling within `.delay` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 ### Removed <!-- for now removed features. -->
 ### Fixed <!-- for any bug fixes. -->
 
+## [0.4.0] - 2021-11-30
+### Fixed
+- Fix Ruby 3.0 kwarg compatibility issue when executing jobs enqueued via the
+  `Delayed::MessageSending` APIs (`.delay` and `handle_asynchronously`).
+### Changed
+- `Delayed::PerformableMethod` now splits `kwargs` out into a separate attribute, while still being
+  backwards-compatible with jobs enqueued via the previous gem version. This is an undocumented
+  internal API and is not considered a breaking change, but if you had previously relied on
+  `payload_object.args.last` to access keyword arguments, you must now use `payload_object.kwargs`.
+
 ## [0.3.0] - 2021-10-26
 ### Added
 - Add more official support for Rails 7.0 (currently alpha2). There were no gem conflicts, but this
@@ -43,6 +53,7 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
   ancestor repos (`delayed_job` and `delayed_job_active_record`), plus the changes from Betterment's
   internal forks.
 
+[0.4.0]: https://github.com/betterment/delayed/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/betterment/delayed/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/betterment/delayed/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/betterment/delayed/compare/v0.1.0...v0.1.1

--- a/delayed.gemspec
+++ b/delayed.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
   spec.summary        = 'a multi-threaded, SQL-driven ActiveJob backend used at Betterment to process millions of background jobs per day'
 
-  spec.version        = '0.3.0'
+  spec.version        = '0.4.0'
   spec.metadata       = {
     'changelog_uri' => 'https://github.com/betterment/delayed/blob/main/CHANGELOG.md',
     'bug_tracker_uri' => 'https://github.com/betterment/delayed/issues',

--- a/delayed.gemspec
+++ b/delayed.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
     'changelog_uri' => 'https://github.com/betterment/delayed/blob/main/CHANGELOG.md',
     'bug_tracker_uri' => 'https://github.com/betterment/delayed/issues',
     'source_code_uri' => 'https://github.com/betterment/delayed',
+    'rubygems_mfa_required' => 'true',
   }
   spec.required_ruby_version = '>= 2.6'
 

--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -18,16 +18,6 @@ module Delayed
       DelayProxy.new(PerformableMethod, self, options)
     end
     alias __delay__ delay
-
-    def send_later(method, *args)
-      warn '[DEPRECATION] `object.send_later(:method)` is deprecated. Use `object.delay.method'
-      __delay__.__send__(method, *args)
-    end
-
-    def send_at(time, method, *args)
-      warn '[DEPRECATION] `object.send_at(time, :method)` is deprecated. Use `object.delay(:run_at => time).method'
-      __delay__(run_at: time).__send__(method, *args)
-    end
   end
 
   module MessageSendingClassMethods

--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -8,8 +8,8 @@ module Delayed
       @options = options
     end
 
-    def method_missing(method, *args)
-      Job.enqueue({ payload_object: @payload_class.new(@target, method.to_sym, args) }.merge(@options))
+    def method_missing(method, *args, **kwargs)
+      Job.enqueue({ payload_object: @payload_class.new(@target, method.to_sym, args, kwargs) }.merge(@options))
     end
   end
 
@@ -36,7 +36,7 @@ module Delayed
       punctuation = $1 # rubocop:disable Style/PerlBackrefs
       with_method = "#{aliased_method}_with_delay#{punctuation}"
       without_method = "#{aliased_method}_without_delay#{punctuation}"
-      define_method(with_method) do |*args|
+      define_method(with_method) do |*args, **kwargs|
         curr_opts = opts.clone
         curr_opts.each_key do |key|
           next unless (val = curr_opts[key]).is_a?(Proc)
@@ -47,7 +47,7 @@ module Delayed
                              val.call
                            end
         end
-        delay(curr_opts).__send__(without_method, *args)
+        delay(curr_opts).__send__(without_method, *args, **kwargs)
       end
 
       alias_method without_method, method

--- a/lib/delayed/performable_mailer.rb
+++ b/lib/delayed/performable_mailer.rb
@@ -3,7 +3,7 @@ require 'mail'
 module Delayed
   class PerformableMailer < PerformableMethod
     def perform
-      mailer = object.send(method_name, *args)
+      mailer = super
       mailer.respond_to?(:deliver_now) ? mailer.deliver_now : mailer.deliver
     end
   end

--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -26,7 +26,7 @@ module Delayed
     def perform
       return unless object
 
-      if kwargs.nil? # TODO: Remove this branch in the next major release. (It will be 'nil' for jobs enqueued before we split out kwargs.)
+      if kwargs.nil? || (RUBY_VERSION < '2.7' && kwargs.empty?)
         object.send(method_name, *args)
       else
         object.send(method_name, *args, **kwargs)

--- a/lib/delayed/psych_ext.rb
+++ b/lib/delayed/psych_ext.rb
@@ -6,6 +6,7 @@ module Delayed
         'object' => object,
         'method_name' => method_name,
         'args' => args,
+        'kwargs' => kwargs,
       }
     end
   end

--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -223,6 +223,25 @@ RSpec.describe Delayed::ActiveJobAdapter do
       end
     end
 
+    context 'when ActiveJob has both positional and keyword arguments' do
+      let(:job_class) do
+        Class.new(ActiveJob::Base) do # rubocop:disable Rails/ApplicationJob
+          cattr_accessor(:result)
+
+          def perform(arg, kwarg:)
+            self.class.result = [arg, kwarg]
+          end
+        end
+      end
+
+      it 'passes arguments through to the perform method' do
+        JobClass.perform_later('foo', kwarg: 'bar')
+
+        Delayed::Worker.new.work_off
+        expect(JobClass.result).to eq %w(foo bar)
+      end
+    end
+
     context 'when using the ActiveJob test adapter' do
       let(:queue_adapter) { :test }
 

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -352,7 +352,7 @@ describe Delayed::Job do
   context 'large handler' do
     before do
       text = 'Lorem ipsum dolor sit amet. ' * 1000
-      @job = described_class.enqueue Delayed::PerformableMethod.new(text, :length, {})
+      @job = described_class.enqueue Delayed::PerformableMethod.new(text, :length, [], {})
     end
 
     it 'has an id' do

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -7,24 +7,26 @@ describe Delayed::MessageSending do
   end
 
   describe 'handle_asynchronously' do
-    class Story
-      def tell!(_arg); end
-      handle_asynchronously :tell!
+    let(:test_class) do
+      Class.new do
+        def tell!(_arg, _kwarg:); end
+        handle_asynchronously :tell!
+      end
     end
 
     it 'aliases original method' do
-      expect(Story.new).to respond_to(:tell_without_delay!)
-      expect(Story.new).to respond_to(:tell_with_delay!)
+      expect(test_class.new).to respond_to(:tell_without_delay!)
+      expect(test_class.new).to respond_to(:tell_with_delay!)
     end
 
     it 'creates a PerformableMethod' do
-      story = Story.create
+      obj = test_class.new
       expect {
-        job = story.tell!(1)
+        job = obj.tell!('a', kwarg: 'b')
         expect(job.payload_object.class).to eq(Delayed::PerformableMethod)
         expect(job.payload_object.method_name).to eq(:tell_without_delay!)
-        expect(job.payload_object.args).to eq([1])
-      }.to(change { Delayed::Job.count })
+        expect(job.payload_object.args).to eq(['a', { kwarg: 'b' }])
+      }.to change { Delayed::Job.count }.by(1)
     end
 
     describe 'with options' do
@@ -64,14 +66,20 @@ describe Delayed::MessageSending do
   end
 
   context 'delay' do
-    class FairyTail
-      attr_accessor :happy_ending
+    let(:fairy_tail_class) do
+      Class.new do
+        attr_accessor :happy_ending
 
-      def self.princesses; end
+        def self.princesses; end
 
-      def tell
-        @happy_ending = true
+        def tell(arg, kwarg:)
+          @happy_ending = [arg, kwarg]
+        end
       end
+    end
+
+    before do
+      stub_const('FairyTail', fairy_tail_class)
     end
 
     after do
@@ -80,10 +88,10 @@ describe Delayed::MessageSending do
 
     it 'creates a new PerformableMethod job' do
       expect {
-        job = 'hello'.delay.count('l')
+        job = FairyTail.new.delay.tell('arg', kwarg: 'kwarg')
         expect(job.payload_object.class).to eq(Delayed::PerformableMethod)
-        expect(job.payload_object.method_name).to eq(:count)
-        expect(job.payload_object.args).to eq(['l'])
+        expect(job.payload_object.method_name).to eq(:tell)
+        expect(job.payload_object.args).to eq(['arg', { kwarg: 'kwarg' }])
       }.to change { Delayed::Job.count }.by(1)
     end
 
@@ -111,8 +119,8 @@ describe Delayed::MessageSending do
       fairy_tail = FairyTail.new
       expect {
         expect {
-          fairy_tail.delay.tell
-        }.to change { fairy_tail.happy_ending }.from(nil).to(true)
+          fairy_tail.delay.tell('a', kwarg: 'b')
+        }.to change { fairy_tail.happy_ending }.from(nil).to %w(a b)
       }.not_to(change { Delayed::Job.count })
     end
 
@@ -121,7 +129,7 @@ describe Delayed::MessageSending do
       fairy_tail = FairyTail.new
       expect {
         expect {
-          fairy_tail.delay.tell
+          fairy_tail.delay.tell('a', kwarg: 'b')
         }.not_to change { fairy_tail.happy_ending }
       }.to change { Delayed::Job.count }.by(1)
     end
@@ -131,7 +139,7 @@ describe Delayed::MessageSending do
       fairy_tail = FairyTail.new
       expect {
         expect {
-          fairy_tail.delay.tell
+          fairy_tail.delay.tell('a', kwarg: 'b')
         }.not_to change { fairy_tail.happy_ending }
       }.to change { Delayed::Job.count }.by(1)
     end
@@ -141,8 +149,8 @@ describe Delayed::MessageSending do
       fairy_tail = FairyTail.new
       expect {
         expect {
-          fairy_tail.delay.tell
-        }.to change { fairy_tail.happy_ending }.from(nil).to(true)
+          fairy_tail.delay.tell('a', kwarg: 'b')
+        }.to change { fairy_tail.happy_ending }.from(nil).to %w(a b)
       }.not_to(change { Delayed::Job.count })
     end
   end

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -25,7 +25,8 @@ describe Delayed::MessageSending do
         job = obj.tell!('a', kwarg: 'b')
         expect(job.payload_object.class).to eq(Delayed::PerformableMethod)
         expect(job.payload_object.method_name).to eq(:tell_without_delay!)
-        expect(job.payload_object.args).to eq(['a', { kwarg: 'b' }])
+        expect(job.payload_object.args).to eq(['a'])
+        expect(job.payload_object.kwargs).to eq(kwarg: 'b')
       }.to change { Delayed::Job.count }.by(1)
     end
 
@@ -91,7 +92,8 @@ describe Delayed::MessageSending do
         job = FairyTail.new.delay.tell('arg', kwarg: 'kwarg')
         expect(job.payload_object.class).to eq(Delayed::PerformableMethod)
         expect(job.payload_object.method_name).to eq(:tell)
-        expect(job.payload_object.args).to eq(['arg', { kwarg: 'kwarg' }])
+        expect(job.payload_object.args).to eq(['arg'])
+        expect(job.payload_object.kwargs).to eq(kwarg: 'kwarg')
       }.to change { Delayed::Job.count }.by(1)
     end
 

--- a/spec/performable_mailer_spec.rb
+++ b/spec/performable_mailer_spec.rb
@@ -1,58 +1,40 @@
 require 'helper'
 
-class MyMailer < ActionMailer::Base
-  def signup(email)
-    mail to: email, subject: 'Delaying Emails', from: 'delayedjob@example.com', body: 'Delaying Emails Body'
-  end
-end
+describe Delayed::PerformableMailer do
+  let(:mailer_class) do
+    Class.new(ActionMailer::Base) do
+      cattr_accessor(:emails) { [] }
 
-describe ActionMailer::Base do
-  describe 'delay' do
-    it 'enqueues a PerformableEmail job' do
-      expect {
-        job = MyMailer.delay.signup('john@example.com')
-        expect(job.payload_object.class).to eq(Delayed::PerformableMailer)
-        expect(job.payload_object.method_name).to eq(:signup)
-        expect(job.payload_object.args).to eq(['john@example.com'])
-      }.to change { Delayed::Job.count }.by(1)
-    end
-  end
-
-  describe 'delay on a mail object' do
-    it 'raises an exception' do
-      expect {
-        MyMailer.signup('john@example.com').delay
-      }.to raise_error(RuntimeError)
-    end
-  end
-
-  describe Delayed::PerformableMailer do
-    describe 'perform' do
-      it 'calls the method and #deliver on the mailer' do
-        email = double('email', deliver: true)
-        mailer_class = double('MailerClass', signup: email)
-        mailer = described_class.new(mailer_class, :signup, ['john@example.com'])
-
-        expect(mailer_class).to receive(:signup).with('john@example.com')
-        expect(email).to receive(:deliver)
-        mailer.perform
+      def signup(email, beta_tester: false)
+        mail to: email, subject: "Delaying Emails (beta: #{beta_tester})", from: 'delayedjob@example.com', body: 'Delaying Emails Body'
       end
     end
   end
-end
 
-if defined?(ActionMailer::Parameterized::Mailer)
-  describe ActionMailer::Parameterized::Mailer do
+  before do
+    stub_const('MyMailer', mailer_class)
+  end
+
+  describe 'perform' do
+    it 'calls the method and #deliver on the mailer' do
+      mailer = MyMailer.new
+      email = double('email', deliver: true)
+      allow(mailer).to receive(:mail).and_return(email)
+      mailer_job = described_class.new(mailer, :signup, ['john@example.com'])
+
+      expect(email).to receive(:deliver)
+      mailer_job.perform
+    end
+  end
+
+  describe ActionMailer::Base do
     describe 'delay' do
       it 'enqueues a PerformableEmail job' do
         expect {
-          job = MyMailer.with(foo: 1, bar: 2).delay.signup('john@example.com')
+          job = MyMailer.delay.signup('john@example.com', beta_tester: true)
           expect(job.payload_object.class).to eq(Delayed::PerformableMailer)
-          expect(job.payload_object.object.class).to eq(described_class)
-          expect(job.payload_object.object.instance_variable_get('@mailer')).to eq(MyMailer)
-          expect(job.payload_object.object.instance_variable_get('@params')).to eq(foo: 1, bar: 2)
           expect(job.payload_object.method_name).to eq(:signup)
-          expect(job.payload_object.args).to eq(['john@example.com'])
+          expect(job.payload_object.args).to eq(['john@example.com', { beta_tester: true }])
         }.to change { Delayed::Job.count }.by(1)
       end
     end
@@ -60,8 +42,34 @@ if defined?(ActionMailer::Parameterized::Mailer)
     describe 'delay on a mail object' do
       it 'raises an exception' do
         expect {
-          MyMailer.with(foo: 1, bar: 2).signup('john@example.com').delay
+          MyMailer.signup('john@example.com').delay
         }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  if defined?(ActionMailer::Parameterized::Mailer)
+    describe ActionMailer::Parameterized::Mailer do
+      describe 'delay' do
+        it 'enqueues a PerformableEmail job' do
+          expect {
+            job = MyMailer.with(foo: 1, bar: 2).delay.signup('john@example.com')
+            expect(job.payload_object.class).to eq(Delayed::PerformableMailer)
+            expect(job.payload_object.object.class).to eq(described_class)
+            expect(job.payload_object.object.instance_variable_get('@mailer')).to eq(MyMailer)
+            expect(job.payload_object.object.instance_variable_get('@params')).to eq(foo: 1, bar: 2)
+            expect(job.payload_object.method_name).to eq(:signup)
+            expect(job.payload_object.args).to eq(['john@example.com'])
+          }.to change { Delayed::Job.count }.by(1)
+        end
+      end
+
+      describe 'delay on a mail object' do
+        it 'raises an exception' do
+          expect {
+            MyMailer.with(foo: 1, bar: 2).signup('john@example.com').delay
+          }.to raise_error(RuntimeError)
+        end
       end
     end
   end

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -2,8 +2,18 @@ require 'helper'
 
 describe Delayed::PerformableMethod do
   describe 'perform' do
+    let(:test_class) do
+      Class.new do
+        cattr_accessor :result
+
+        def foo(arg, kwarg:)
+          self.class.result = [arg, kwarg]
+        end
+      end
+    end
+
     before do
-      @method = described_class.new('foo', :count, ['o'])
+      @method = described_class.new(test_class.new, :foo, ['a', { kwarg: 'b' }])
     end
 
     context 'with the persisted record cannot be found' do
@@ -17,8 +27,9 @@ describe Delayed::PerformableMethod do
     end
 
     it 'calls the method on the object' do
-      expect(@method.object).to receive(:count).with('o')
-      @method.perform
+      expect { @method.perform }
+        .to change { test_class.result }
+        .from(nil).to %w(a b)
     end
   end
 

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -31,6 +31,20 @@ describe Delayed::PerformableMethod do
         .to change { test_class.result }
         .from(nil).to %w(a b)
     end
+
+    if RUBY_VERSION < '3.0'
+      context 'when kwargs are nil (job was delayed via prior gem version)' do
+        before do
+          @method = described_class.new(test_class.new, :foo, ['a', { kwarg: 'b' }], nil)
+        end
+
+        it 'calls the method on the object' do
+          expect { @method.perform }
+            .to change { test_class.result }
+            .from(nil).to %w(a b)
+        end
+      end
+    end
   end
 
   it "raises a NoMethodError if target method doesn't exist" do

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -13,7 +13,7 @@ describe Delayed::PerformableMethod do
     end
 
     before do
-      @method = described_class.new(test_class.new, :foo, ['a', { kwarg: 'b' }])
+      @method = described_class.new(test_class.new, :foo, ['a'], { kwarg: 'b' })
     end
 
     context 'with the persisted record cannot be found' do
@@ -35,7 +35,7 @@ describe Delayed::PerformableMethod do
 
   it "raises a NoMethodError if target method doesn't exist" do
     expect {
-      described_class.new(Object, :method_that_does_not_exist, [])
+      described_class.new(Object, :method_that_does_not_exist, [], {})
     }.to raise_error(NoMethodError)
   end
 
@@ -44,29 +44,29 @@ describe Delayed::PerformableMethod do
       def private_method; end
       private :private_method
     end
-    expect { described_class.new(clazz.new, :private_method, []) }.not_to raise_error
+    expect { described_class.new(clazz.new, :private_method, [], {}) }.not_to raise_error
   end
 
   context 'when it receives an object that is not persisted' do
     let(:object) { double(persisted?: false, expensive_operation: true) }
 
     it 'raises an ArgumentError' do
-      expect { described_class.new(object, :expensive_operation, []) }.to raise_error ArgumentError
+      expect { described_class.new(object, :expensive_operation, [], {}) }.to raise_error ArgumentError
     end
 
     it 'does not raise ArgumentError if the object acts like a Her model' do
       allow(object.class).to receive(:save_existing).and_return(true)
-      expect { described_class.new(object, :expensive_operation, []) }.not_to raise_error
+      expect { described_class.new(object, :expensive_operation, [], {}) }.not_to raise_error
     end
   end
 
   describe 'display_name' do
     it 'returns class_name#method_name for instance methods' do
-      expect(described_class.new('foo', :count, ['o']).display_name).to eq('String#count')
+      expect(described_class.new('foo', :count, ['o'], {}).display_name).to eq('String#count')
     end
 
     it 'returns class_name.method_name for class methods' do
-      expect(described_class.new(Class, :inspect, []).display_name).to eq('Class.inspect')
+      expect(described_class.new(Class, :inspect, [], {}).display_name).to eq('Class.inspect')
     end
   end
 
@@ -95,7 +95,7 @@ describe Delayed::PerformableMethod do
     end
 
     it 'delegates failure hook to object' do
-      method = described_class.new('object', :size, [])
+      method = described_class.new('object', :size, [], {})
       expect(method.object).to receive(:failure)
       method.failure
     end
@@ -125,7 +125,7 @@ describe Delayed::PerformableMethod do
       end
 
       it 'delegates failure hook to object' do
-        method = described_class.new('object', :size, [])
+        method = described_class.new('object', :size, [], {})
         expect(method.object).to receive(:failure)
         method.failure
       end


### PR DESCRIPTION
/domain @effron @samandmoore 
/platform @effron @samandmoore 

Resolves #6. While we already fully support Ruby 3.0 kwargs via ActiveJob, the legacy `delay` and `handle_asynchronously` APIs did not support the new [separation of positional and keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) introduced in 2.7 and enforced in 3.0.

This means that methods accepting both positional and keyword arguments (e.g. `def foo(a, b:)`) would fail with a `wrong number of arguments (given 2, expected 1; required keyword:)` error on Ruby 3. In order to resolve this, this PR changes `Delayed::PerformableMethod` to handle kwargs separately from args, with a backwards compatibility check for any Ruby 2.6 methods that do not accept keyword arguments. It should also support jobs that were enqueued by the prior `delayed` gem version (where the new `kwargs` accessor would be nil, and `args` contains the kwargs as its last item).