### PR TITLE
Create a JobRecord abstract parent class for Delayed::Job

### DIFF
--- a/app/models/delayed/job.rb
+++ b/app/models/delayed/job.rb
@@ -1,5 +1,5 @@
 module Delayed
-  class Job < ::ActiveRecord::Base
+  class Job < JobRecord
     include Delayed::Backend::Base
 
     scope :by_priority, lambda { order("priority ASC, run_at ASC") }
@@ -20,7 +20,7 @@ module Delayed
     REENQUEUE_BUFFER = 30.seconds
 
     def self.set_delayed_job_table_name
-      delayed_job_table_name = "#{::ActiveRecord::Base.table_name_prefix}delayed_jobs"
+      delayed_job_table_name = "#{JobRecord.table_name_prefix}delayed_jobs"
       self.table_name = delayed_job_table_name
     end
 

--- a/app/models/delayed/job_record.rb
+++ b/app/models/delayed/job_record.rb
@@ -1,0 +1,5 @@
+module Delayed
+  class JobRecord < ::ActiveRecord::Base
+    self.abstract_class = true
+  end
+end


### PR DESCRIPTION
This is a simple refactor that opens the doors to an experiment that I was running to used `Delayed` with a separate SQLite database. In order to get this to work tho, I needed an abstract class extension point to call `connects_to` on (https://api.rubyonrails.org/classes/ActiveRecord/ConnectionHandling.html#method-i-connects_to). 

I am going to open up a separate issue to discuss that experiment in more detail, but I'm hoping this minor tweak to the structure can be added now to provide such possibilities.