### PR TITLE
Fix Rails 7.1 regression: Delayed::JobWrapper not defined

### DIFF
--- a/delayed.gemspec
+++ b/delayed.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
   spec.summary        = 'a multi-threaded, SQL-driven ActiveJob backend used at Betterment to process millions of background jobs per day'
 
-  spec.version        = '0.5.1'
+  spec.version        = '0.5.2'
   spec.metadata       = {
     'changelog_uri' => 'https://github.com/betterment/delayed/blob/main/CHANGELOG.md',
     'bug_tracker_uri' => 'https://github.com/betterment/delayed/issues',

--- a/lib/delayed.rb
+++ b/lib/delayed.rb
@@ -14,6 +14,7 @@ require 'delayed/plugins/instrumentation'
 require 'delayed/backend/base'
 require 'delayed/backend/job_preparer'
 require 'delayed/worker'
+require 'delayed/job_wrapper'
 
 if defined?(Rails::Engine)
   require 'delayed/engine'

--- a/lib/delayed/active_job_adapter.rb
+++ b/lib/delayed/active_job_adapter.rb
@@ -36,34 +36,4 @@ module Delayed
       end
     end
   end
-
-  class JobWrapper # rubocop:disable Betterment/ActiveJobPerformable
-    attr_accessor :job_data
-
-    delegate_missing_to :job
-
-    def initialize(job_data)
-      @job_data = job_data
-    end
-
-    def display_name
-      job_data['job_class']
-    end
-
-    def perform
-      ActiveJob::Callbacks.run_callbacks(:execute) do
-        job.perform_now
-      end
-    end
-
-    def encode_with(coder)
-      coder['job_data'] = @job_data
-    end
-
-    private
-
-    def job
-      @job ||= ActiveJob::Base.deserialize(job_data) if job_data
-    end
-  end
 end

--- a/lib/delayed/job_wrapper.rb
+++ b/lib/delayed/job_wrapper.rb
@@ -1,0 +1,31 @@
+module Delayed
+  class JobWrapper # rubocop:disable Betterment/ActiveJobPerformable
+    attr_accessor :job_data
+
+    delegate_missing_to :job
+
+    def initialize(job_data)
+      @job_data = job_data
+    end
+
+    def display_name
+      job_data['job_class']
+    end
+
+    def perform
+      ActiveJob::Callbacks.run_callbacks(:execute) do
+        job.perform_now
+      end
+    end
+
+    def encode_with(coder)
+      coder['job_data'] = @job_data
+    end
+
+    private
+
+    def job
+      @job ||= ActiveJob::Base.deserialize(job_data) if job_data
+    end
+  end
+end


### PR DESCRIPTION
This fixes #29, which can be reproduced on new Rails 7.1.1 apps in development.

The issue stems from the fact that Rails no longer loads ActiveJob at all until the first `ActiveJob::Base` class is referenced, but we defined our `Delayed::JobWrapper` class in a file that only loads _after_ ActiveJob loads. This means that you can enqueue an ActiveJob, but the first time `delayed:work` tries to deserialize the handler, it encounters the `Delayed::JobWrapper` constant before it encounters its first `ActiveJob::Base` class.

The fix is to pull `Delayed::JobWrapper` out into its own file in `lib/` and load it when `lib/delayed.rb` loads. The class itself has no dependencies outside of `activesupport` (`delegate_missing_to`) so this is safe enough to do.

/no-platform