### PR TITLE
Optimize JobWrapper queueing ActiveJobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 ### Removed <!-- for now removed features. -->
 ### Fixed <!-- for any bug fixes. -->
 
-- Bring ActiveJob queue adapter's enqueuing behaviour inline with delayed_job &
-  upstream adapters, by stopping it serializing & deserializing the job instance
-  during the enqueue process.
+## [0.5.1] - 2023-10-11
+### Changed
+
+- Explicitly test Rails 7.1 and Ruby 3.1, Ruby 3.2 to verify compatability. Previous
+  gems were compatible, but this release is now verified to be compatible.
 
 ## [0.5.0] - 2023-01-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 ### Removed <!-- for now removed features. -->
 ### Fixed <!-- for any bug fixes. -->
 
+- Bring ActiveJob queue adapter's enqueuing behaviour inline with delayed_job &
+  upstream adapters, by stopping it serializing & deserializing the job instance
+  during the enqueue process.
+
 ## [0.5.0] - 2023-01-20
 ### Changed
 - Reduced handler size by excluding redundant 'job:' key (only 'job_data:' is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 ### Removed <!-- for now removed features. -->
 ### Fixed <!-- for any bug fixes. -->
 
+## [0.5.3] - 2024-01-12
+### Changed
+
+- Bring ActiveJob queue adapter's enqueuing behaviour inline with delayed_job &
+  upstream adapters, by stopping it serializing & deserializing the job instance
+  during the enqueue process. Optimises the enqueueing of jobs slightly too.
+
 ## [0.5.2] - 2023-10-19
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 ### Removed <!-- for now removed features. -->
 ### Fixed <!-- for any bug fixes. -->
 
+## [0.5.2] - 2023-10-19
+### Fixed
+
+- Fixed regression for Rails 7.1.1 not executing jobs, due to lazy loading change in Rails.
+  The `JobWrapper` needs to be loaded before `ActiveJob::Base` is loaded, but this wasn't
+  happening in the worker processes. Fix by extracting `JobWrapper` into it's own file and
+  loading when `Delayed` is loaded earlier in the process.
+
 ## [0.5.1] - 2023-10-11
 ### Changed
 

--- a/delayed.gemspec
+++ b/delayed.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
   spec.summary        = 'a multi-threaded, SQL-driven ActiveJob backend used at Betterment to process millions of background jobs per day'
 
-  spec.version        = '0.5.2'
+  spec.version        = '0.5.3'
   spec.metadata       = {
     'changelog_uri' => 'https://github.com/betterment/delayed/blob/main/CHANGELOG.md',
     'bug_tracker_uri' => 'https://github.com/betterment/delayed/issues',

--- a/lib/delayed/active_job_adapter.rb
+++ b/lib/delayed/active_job_adapter.rb
@@ -14,7 +14,7 @@ module Delayed
       opts.merge!({ queue: job.queue_name, priority: job.priority }.compact)
         .merge!(job.provider_attributes || {})
 
-      Delayed::Job.enqueue(JobWrapper.new(job.serialize), opts).tap do |dj|
+      Delayed::Job.enqueue(JobWrapper.new(job), opts).tap do |dj|
         job.provider_job_id = dj.id
       end
     end

--- a/lib/delayed/job_wrapper.rb
+++ b/lib/delayed/job_wrapper.rb
@@ -10,7 +10,7 @@ module Delayed
       # During load from the db, we get a data hash passed in so deserialize lazily.
       if job_or_data.is_a?(ActiveJob::Base)
         @job = job_or_data
-        @job_data = job.serialize
+        @job_data = job_or_data.serialize
       else
         @job_data = job_or_data
       end
@@ -33,9 +33,7 @@ module Delayed
     private
 
     def job
-      return @job if defined?(@job)
-
-      @job = ActiveJob::Base.deserialize(job_data) if job_data
+      @job ||= ActiveJob::Base.deserialize(job_data) if job_data
     end
   end
 end

--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe Delayed::ActiveJobAdapter do
     ActiveJob::Base.queue_adapter = adapter_was
   end
 
+  it "does not invoke #deserialize during enqueue" do # rubocop:disable RSpec/NoExpectationExample
+    JobClass.include(Module.new do
+      def deserialize(*)
+        raise "uh oh, deserialize called during enqueue!"
+      end
+    end)
+
+    JobClass.perform_later
+  end
+
   it 'serializes a JobWrapper in the handler with expected fields' do
     Timecop.freeze('2023-01-20T18:52:29Z') do
       JobClass.perform_later


### PR DESCRIPTION
This PR introduces a change to avoid calling `ActiveJob::Base#deserialize` during queueing the job whilst maintaining existing functionality.

The change is in `JobWrapper`, which previously only took in a hash of `job_data` and knew how to deserialize it into a job object so we can interrogate it for `queue_name` or `max_attempts`, etc. To avoid the roundtrip through serialization, we change `JobWrapper#initialize` to take in either the job object directly, or a hash as it did previously. When it's a hash (needed when running the job in the worker), it still deserializes it into a job object. When it's a job object just assign it to `@job` directly and continue.

We discovered this through having a second-order effect in `#deserialize` using it to trigger some logic as the job comes off the queue, but we were then seeing the logic run multiple times for one job execution. Tracked it back to the `JobClass.perform_later` calling `#deserialize` and being majorly confused why it was deserialising in the web process.

This will make enqueueing jobs faster too, because we don't need a roundtrip through `#serialize`, `#deserialize` as well as allocating less objects. In practice this is likely a small effect, but we get it for free avoiding the behaviour above.

Looking at all the [built-in adapters in ActiveJob][aj], as well as good_job and solid_queue, they all avoid calling `job.serialize` during the enqueuing, even those adapters that support invoking methods on the Job class instance like delayed does.

[aj]: https://github.com/rails/rails/tree/v7.1.2/activejob/lib/active_job/queue_adapters
[good_job]: https://github.com/bensheldon/good_job/blob/main/app/models/good_job/execution.rb#L210
[solid_queue]: https://github.com/basecamp/solid_queue/blob/3c704514cda82244e022c6ae945a51f8c147c4b3/app/models/solid_queue/job.rb#L26C13-L26C13

From one angle it's an optimization, from another angle it's a bugfix (: