### PR TITLE
Fix vanishing thread data between deserialising and performing an ActiveJob instance

### DIFF
--- a/lib/delayed/job_wrapper.rb
+++ b/lib/delayed/job_wrapper.rb
@@ -13,9 +13,7 @@ module Delayed
     end
 
     def perform
-      ActiveJob::Callbacks.run_callbacks(:execute) do
-        job.perform_now
-      end
+      ActiveJob::Base.execute(job_data)
     end
 
     def encode_with(coder)

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -549,6 +549,36 @@ describe Delayed::Job do
           expect(job).to be_failed
         end
       end
+
+      describe 'handing off to ActiveJob' do
+        around do |example|
+          old_adapter, ActiveJob::Base.queue_adapter = ActiveJob::Base.queue_adapter, :delayed
+          example.run
+        ensure
+          ActiveJob::Base.queue_adapter = old_adapter
+        end
+
+        it 'runs everything under the same executor block' do
+          # Ensure the current attributes are persisted in the job, but then reset in this process
+          ActiveJobAttributesJob.results.clear
+          ActiveJobAttributesJob::Current.user_id = 0xC0FFEE
+          ActiveJobAttributesJob.perform_later
+          ActiveJobAttributesJob::Current.clear_all
+
+          # In a rails app this is in ActiveJob's railtie, wrapping the execute in an around callback that
+          # leans on the Rails executor to reset things in jobs. Fake it here with execute around callback
+          # setup the same, and only clear CurrentAttributes directly.
+          ActiveJob::Callbacks.singleton_class.set_callback(:execute, :around, prepend: true) do |_, inner|
+            ActiveSupport::CurrentAttributes.clear_all
+            inner.call
+          end
+
+          worker.work_off
+
+          expect(ActiveJobAttributesJob::Current.user_id).to be_nil
+          expect(ActiveJobAttributesJob.results).to eq([0xC0FFEE])
+        end
+      end
     end
 
     describe 'failed jobs' do

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -115,3 +115,26 @@ end
 class ActiveJobJob < ActiveJob::Base # rubocop:disable Rails/ApplicationJob
   def perform; end
 end
+
+class ActiveJobAttributesJob < ActiveJobJob
+  class Current < ActiveSupport::CurrentAttributes
+    attribute :user_id
+  end
+
+  def self.results
+    @results ||= []
+  end
+
+  def serialize
+    super.merge("user_id" => Current.user_id)
+  end
+
+  def deserialize(job_data)
+    super
+    Current.user_id = job_data["user_id"]
+  end
+
+  def perform
+    self.class.results << Current.user_id
+  end
+end


### PR DESCRIPTION
Change `Delayed::JobWrapper` from directly invoking `:execute` callbacks and `job#perform_now`, to instead calling `ActiveJob::Base.execute` and letting ActiveJob handle the callbacks, job deserialisation and performing internally.

To explain why, we've observed a change in behaviour between `delayed_job`'s queue adapter and `delayed`'s queue adapter with thread variables being reset between `job#deserialize` and `job#perform` being called from the same worker thread/process.

*Some background context around the Rails executor and ActiveSupport::CurrentAttributes is useful. Feel free to skip down a couple of paragraphs if you already understand them!*

The ActiveJob Railtie has [an initialiser that wraps all job executions with the Rails executor][activejob-executor-initialiser] (it calls `app.reloader` in the code, but that's effectively the executor still.) This ensures code is reloaded between jobs running in development mode, but also makes sure any executor callbacks are invoked when the reloader block is entered at runtime in any environment. (If you've ever wondered how things in rails get reset between web requests, this mechanism is the answer.)

[activejob-executor-initialiser]: https://github.com/rails/rails/blob/v7.1.2/activejob/lib/active_job/railtie.rb#L63-L71

The ActiveSupport Railtie has [an initialiser that resets `ActiveSupport::CurrentAttributes` instances when entering an executor block][activesupport-current-attributes-initializer]. This means before every job is run, all subclasses/instances of `ActiveSupport::CurrentAttributes` have their values cleared which stops things leaking between requests/jobs/blocks of work. This effectively lets you have thread-global variables that are cleaned up once the current unit of work has finished, without you needing to remember.

[activesupport-current-attributes-initializer]: https://github.com/rails/rails/blob/v7.1.2/activesupport/lib/active_support/railtie.rb#L47-L64

In our app we're using the Rails default `Current` model which is a subclass of `ActiveSupport::CurrentAttributes` to store some request-global information about an external service to use. (This allows us to override that on a per-request basis in non-production environments for testing purposes.) We pass that override down into the jobs at enqueue time by overriding `ApplicationJob#serialize` to save the value of `Current.service_url` into the job data hash.

```ruby
class ApplicationJob < ActiveJob::Base
  def serialize
    super.merge("service_url" => Current.service_url)
  end

  def deserialize(job_data)
    super
    Current.service_url = job_data.delete("service_url")
  end
end
```

Our code in `SomeJob#perform` and elsewhere in the app invoked from the job can then call `Current.service_url` to find the overridden value. Doing it this way means the behaviour is shared between all jobs that need that overridden url without having to remember to override `serialize`/`deserialize` in each job when required.

Switching from `delayed_job` to `delayed` broke this mechanism silently 😬. No errors were raised but our override wasn't being observed in the code. Debugging it we observed within the `ApplicationJob#deserialize` method `Current.service_url` was being set correctly, but by the time the `job#perform` method was called `Current.service_url` was `nil` again. The case of the vanishing variable?! 🙀

At this point we deduced it was likely an ordering issue around `ActiveSupport::CurrentAttributes` being reset and investigated further in that direction. After littering `puts` statements through `delayed` and `ActiveJob` I think we've figured out why this is occurring and how it differs to `delayed_job`'s behaviour.

We see `JobWrapper#job` being invoked early in the worker method in `Delayed::Worker#run`, via `Delayed::Worker#max_run_time` seeing if the job instance responds to `#max_run_time`. DJ Hooks will also use the job instance (`payload_object`). JobWrapper forwards all missing methods to the `job` method, which deserialises the job object from the data.

The `JobWrapper#perform` method then re-uses the `@job` memoized instance in when invoking execute callbacks (which reset all the `ActiveSupport::CurrentAttributes` values) then calls `job.perform_now` without invoking `#deserialize` again. This means we've deserialised the job, then invoked the Rails executor entry callbacks, then called `job#perform`. Subtle, but unexpected (to us at least) behaviour change.

This PR changes `JobWrapper#perform` to call `ActiveJob::Base.execute(job_data)` to have ActiveJob invoke callbacks, deserialize the job and perform it in the correct order. In delayed's case it means `job#deserialize` will be called twice, due to the worker interrogating the job instance before getting to calling `JobWrapper#perform`. The crucial change is that deserialisation happens after the rails executor callbacks, so any override to `job#deserialize` expecting to be run in the same "unit of work" as the `job#perform` method will work.

For reference, the `delayed_job` adapter doesn't deserialize the job_data before calling `ActiveJob::Base.execute` so doesn't have this ordering effect in it. The tradeoff is `delayed_job`'s adapter also doesn't allow overriding `max_run_time`, etc in the job class which is useful.

I can't think of a way to solve this without either breaking the API allowing `max_run_time` methods on job classes (aside from perhaps making them class methods?) or having the side-effect of deserializing the job before the Rails executor entry which can lead to seemingly weird behaviour when using standard Rails executor aware objects in this way.

_(For ease of linking to the source code, the above description links to Rails 7.1.2 source code, but holds true back to Rails 5.0 for ActiveJob and Rails 5.2 for ActiveSupport::CurrentAttributes. Aka the first version each feature appeared respectively.)_
