### PR TITLE
Rails 8 - Deprecate ActiveSupport::ProxyObject

### DIFF
--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -1,7 +1,5 @@
-require 'active_support/proxy_object'
-
 module Delayed
-  class DelayProxy < ActiveSupport::ProxyObject
+  class DelayProxy < BasicObject
     def initialize(payload_class, target, options)
       @payload_class = payload_class
       @target = target


### PR DESCRIPTION
beginning with Rails 8.0.0rc1, Delayed no longer works due to `ActiveSupport::ProxyObject` being dropped.

https://github.com/rails/rails/releases/tag/v8.0.0.rc1

**steps to reproduce**

1. rails new sample_app
2. add delayed 0.5.5 to Gemfile
3. rails c

```
/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require': cannot load such file -- active_support/proxy_object (LoadError)
```