### PR TITLE
Fix Rails 8.0 deprecations

### DIFF
--- a/lib/delayed/active_job_adapter.rb
+++ b/lib/delayed/active_job_adapter.rb
@@ -17,7 +17,7 @@ module Delayed
     private
 
     def _enqueue(job, opts = {})
-      if job.class.respond_to?(:enqueue_after_transaction_commit) && job.class.enqueue_after_transaction_commit == :always
+      if enqueue_after_transaction_commit_enabled?(job)
         raise UnsafeEnqueueError, "The ':delayed' ActiveJob adapter is not compatible with enqueue_after_transaction_commit"
       end
 
@@ -27,6 +27,11 @@ module Delayed
       Delayed::Job.enqueue(JobWrapper.new(job), opts).tap do |dj|
         job.provider_job_id = dj.id
       end
+    end
+
+    def enqueue_after_transaction_commit_enabled?(job)
+      job.class.respond_to?(:enqueue_after_transaction_commit) &&
+        [true, :always].include?(job.class.enqueue_after_transaction_commit)
     end
 
     module EnqueuingPatch

--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -295,7 +295,9 @@ RSpec.describe Delayed::ActiveJobAdapter do
         end
 
         it 'raises an exception on enqueue' do
-          expect { JobClass.perform_later }.to raise_error(Delayed::ActiveJobAdapter::UnsafeEnqueueError)
+          ActiveJob.deprecator.silence do
+            expect { JobClass.perform_later }.to raise_error(Delayed::ActiveJobAdapter::UnsafeEnqueueError)
+          end
         end
       end
 
@@ -306,7 +308,9 @@ RSpec.describe Delayed::ActiveJobAdapter do
         end
 
         it 'does not raises an exception on enqueue' do
-          expect { JobClass.perform_later }.not_to raise_error(Delayed::ActiveJobAdapter::UnsafeEnqueueError)
+          ActiveJob.deprecator.silence do
+            expect { JobClass.perform_later }.not_to raise_error
+          end
         end
       end
     end

--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -315,6 +315,30 @@ RSpec.describe Delayed::ActiveJobAdapter do
       end
     end
 
+    if ActiveJob.gem_version.release >= Gem::Version.new('8.0')
+      context 'when the given job sets enqueue_after_transaction_commit to true' do
+        before do
+          JobClass.include ActiveJob::EnqueueAfterTransactionCommit # normally run in an ActiveJob railtie
+          JobClass.enqueue_after_transaction_commit = true
+        end
+
+        it 'raises an exception on enqueue' do
+          expect { JobClass.perform_later }.to raise_error(Delayed::ActiveJobAdapter::UnsafeEnqueueError)
+        end
+      end
+
+      context 'when the given job sets enqueue_after_transaction_commit to false' do
+        before do
+          JobClass.include ActiveJob::EnqueueAfterTransactionCommit # normally run in an ActiveJob railtie
+          JobClass.enqueue_after_transaction_commit = false
+        end
+
+        it 'does not raises an exception on enqueue' do
+          expect { JobClass.perform_later }.not_to raise_error
+        end
+      end
+    end
+
     context 'when using the ActiveJob test adapter' do
       let(:queue_adapter) { :test }
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,6 +10,13 @@ require 'sample_jobs'
 
 require 'rake'
 
+if ActiveSupport.gem_version >= Gem::Version.new('7.1')
+  frameworks = [ActiveModel, ActiveRecord, ActionMailer, ActiveJob, ActiveSupport]
+  frameworks.each { |framework| framework.deprecator.behavior = :raise }
+else
+  ActiveSupport::Deprecation.behavior = :raise
+end
+
 if ENV['DEBUG_LOGS']
   Delayed.logger = Logger.new($stdout)
 else


### PR DESCRIPTION
I configured deprecations to raise exceptions.

Once I did that, I had to suppress deprecations from `enqueue_after_transaction_commit = :always` and `enqueue_after_transaction_commit = :never`.

Those values are still supported, but deprecated. Rails 8.0 now expects `true` or `false`. I've updated delayed to ensure that `enqueue_after_transaction_commit` is not set to `true`.