### PR TITLE
Delayed 1.0: Lifecycle & job cleanup improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    delayed (0.8.0)
+    delayed (1.0.0)
       activerecord (>= 5.2)
       concurrent-ruby
 

--- a/delayed.gemspec
+++ b/delayed.gemspec
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
+
+require 'delayed/version'
+
 Gem::Specification.new do |spec|
   spec.authors        = ['Nathan Griffith', 'Rowan McDonald', 'Cyrus Eslami', 'John Mileham', 'Brandon Keepers', 'Brian Ryckbost',
                          'Chris Gaffney', 'David Genord II', 'Erik Michaels-Ober', 'Matt Griffin', 'Steve Richert', 'Tobias Lütke']
@@ -18,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
   spec.summary        = 'a multi-threaded, SQL-driven ActiveJob backend used at Betterment to process millions of background jobs per day'
 
-  spec.version        = '0.8.0'
+  spec.version        = Delayed::VERSION
   spec.metadata       = {
     'changelog_uri' => 'https://github.com/betterment/delayed/blob/main/CHANGELOG.md',
     'bug_tracker_uri' => 'https://github.com/betterment/delayed/issues',

--- a/lib/delayed/job_wrapper.rb
+++ b/lib/delayed/job_wrapper.rb
@@ -20,6 +20,12 @@ module Delayed
       job_data['job_class']
     end
 
+    def respond_to?(*, **)
+      super
+    rescue NameError # job failed to deserialize, so we can't respond to delegated methods.
+      false
+    end
+
     def perform
       ActiveJob::Callbacks.run_callbacks(:execute) do
         job.perform_now

--- a/lib/delayed/lifecycle.rb
+++ b/lib/delayed/lifecycle.rb
@@ -8,7 +8,7 @@ module Delayed
       perform: %i(worker job),
       error: %i(worker job),
       failure: %i(worker job),
-      thread: %i(worker job),
+      thread: [:worker],
       invoke_job: [:job],
     }.freeze
 

--- a/lib/delayed/plugins/connection.rb
+++ b/lib/delayed/plugins/connection.rb
@@ -2,9 +2,9 @@ module Delayed
   module Plugins
     class Connection < Plugin
       callbacks do |lifecycle|
-        lifecycle.around(:thread) do |worker, job, &block|
+        lifecycle.around(:thread) do |worker, &block|
           Job.connection_pool.with_connection do
-            block.call(worker, job)
+            block.call(worker)
           end
         end
       end

--- a/lib/delayed/version.rb
+++ b/lib/delayed/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Delayed
+  VERSION = '1.0.0'
+end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -101,7 +101,7 @@ module Delayed
         pool = Concurrent::FixedThreadPool.new(jobs.length)
         jobs.each do |job|
           pool.post do
-            self.class.lifecycle.run_callbacks(:thread, self, job) do
+            self.class.lifecycle.run_callbacks(:thread, self) do
               success.increment if perform(job)
             end
           rescue Exception => e # rubocop:disable Lint/RescueException

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -135,10 +135,6 @@ RSpec.configure do |config|
     min_reserve_interval_was = Delayed::Worker.min_reserve_interval
     plugins_was = Delayed.plugins.dup
 
-    if Gem.loaded_specs['delayed'].version >= Gem::Version.new('1.0') && min_reserve_interval_was.zero?
-      raise "Min reserve interval should be nonzero in v1.0 release"
-    end
-
     Delayed::Worker.sleep_delay = TEST_SLEEP_DELAY
     Delayed::Worker.min_reserve_interval = TEST_MIN_RESERVE_INTERVAL
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -133,6 +133,7 @@ RSpec.configure do |config|
     read_ahead_was = Delayed::Worker.read_ahead
     sleep_delay_was = Delayed::Worker.sleep_delay
     min_reserve_interval_was = Delayed::Worker.min_reserve_interval
+    plugins_was = Delayed.plugins.dup
 
     if Gem.loaded_specs['delayed'].version >= Gem::Version.new('1.0') && min_reserve_interval_was.zero?
       raise "Min reserve interval should be nonzero in v1.0 release"
@@ -158,6 +159,7 @@ RSpec.configure do |config|
     Delayed::Worker.read_ahead = read_ahead_was
     Delayed::Worker.sleep_delay = sleep_delay_was
     Delayed::Worker.min_reserve_interval = min_reserve_interval_was
+    Delayed.plugins = plugins_was
 
     Delayed::Job.delete_all
   end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -42,6 +42,7 @@ db_adapter ||= "sqlite3"
 config = YAML.load(ERB.new(File.read("spec/database.yml")).result)
 ActiveRecord::Base.establish_connection config[db_adapter]
 ActiveRecord::Base.logger = Delayed.logger
+ActiveJob::Base.logger = Delayed.logger
 ActiveRecord::Migration.verbose = false
 
 # MySQL 5.7 no longer supports null default values for the primary key

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,6 +10,12 @@ require 'sample_jobs'
 
 require 'rake'
 
+ActiveSupport.on_load(:active_record) do
+  require 'global_id/identification'
+  include GlobalID::Identification
+  GlobalID.app = 'test'
+end
+
 if ActiveSupport.gem_version >= Gem::Version.new('7.1')
   frameworks = [ActiveModel, ActiveRecord, ActionMailer, ActiveJob, ActiveSupport]
   frameworks.each { |framework| framework.deprecator.behavior = :raise }

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -113,5 +113,5 @@ class EnqueueJobMod < SimpleJob
 end
 
 class ActiveJobJob < ActiveJob::Base # rubocop:disable Rails/ApplicationJob
-  def perform; end
+  def perform(*args, **kwargs); end
 end


### PR DESCRIPTION
This PR bumps us to `1.0.0` because in cleaning up our lifecycle hooks, I made a breaking change to remove the `job` argument from the `:thread` lifecycle callback. Coupling threads & jobs 1:1 was an implementation decision, and we are restricting ourselves by baking that decision into the callback hooks. This also ensures that consuming apps do not have access to the job instance during `:thread` callbacks, making job-level cleanup slightly easier for the framework.

In addition to that change, I wrote more extensive tests around the full callback lifecycle under several different failure conditions to ensure that jobs get cleaned up in all cases, and adjusted the placement of `rescue` calls to match my own expectations of how this framework should handle these failures. This rework aims to prevent "spinloop" scenarios where, due to failed job cleanup, workers get stuck attempting to work off the same jobs over & over. (Even with `locked_at`, these workers can slowly degrade if enough jobs are consistently stuck in a locked state past the lock timeout.)

/no-platform