### PR TITLE
fix: Fix set_name callback, and improve spec coverage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    delayed (1.2.0)
+    delayed (1.2.1)
       activerecord (>= 6.0)
       concurrent-ruby
 

--- a/app/models/delayed/job.rb
+++ b/app/models/delayed/job.rb
@@ -256,8 +256,8 @@ module Delayed
     private
 
     def set_name
-      # [feat:NameColumn] remove 'if' statement once the 'name' column is required.
-      self.name ||= display_name if respond_to?(:name=)
+      # [feat:NameColumn] remove 'if' statement and use `||=` once the 'name' column is required.
+      self.name = display_name if respond_to?(:name=) && attributes.fetch('name').nil?
     end
   end
 end

--- a/lib/delayed/version.rb
+++ b/lib/delayed/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Delayed
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -259,6 +259,7 @@ describe Delayed::Job do
         expect(job.name).to eq('ErrorJob')
         job.save!
         expect(job.reload.name).to eq('ErrorJob')
+        expect(described_class.group(:name).count).to eq('ErrorJob' => 1)
       end
 
       it 'is the class name of the performable job if it is an ActiveJob' do
@@ -267,6 +268,7 @@ describe Delayed::Job do
         expect(job.name).to eq('ActiveJobJob')
         job.save!
         expect(job.reload.name).to eq('ActiveJobJob')
+        expect(described_class.group(:name).count).to eq('ActiveJobJob' => 1)
       end
 
       it 'is the returned display_name if display_name is defined on the job object' do
@@ -274,11 +276,13 @@ describe Delayed::Job do
         expect(job.name).to eq('named_job')
         job.save!
         expect(job.reload.name).to eq('named_job')
+        expect(described_class.group(:name).count).to eq('named_job' => 1)
       end
 
       it 'is the instance method that will be called if its a performable method object' do
         job = Story.create(text: '...').delay.save
         expect(job.name).to eq('Story#save')
+        expect(described_class.group(:name).count).to eq('Story#save' => 1)
       end
 
       it 'is the custom name value when set explicitly' do
@@ -286,6 +290,7 @@ describe Delayed::Job do
         job.name = 'Custom Name'
         job.save!
         expect(job.reload.name).to eq('Custom Name')
+        expect(described_class.group(:name).count).to eq('Custom Name' => 1)
       end
     end
 


### PR DESCRIPTION
This updates the method & tests to properly ensure that the column value gets assigned before_save.

Reason: The `||=` operator results in no assignment, because `name` is overridden for backwards-compatibility if the column does not exist.

/no-platform