### PR TITLE
style: Add (passing) tests for regression coverage

### DIFF
--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -58,6 +58,22 @@ RSpec.describe Delayed::ActiveJobAdapter do
     end
   end
 
+  it 'bubbles out an error if the job fails to serialize' do
+    JobClass.class_eval do
+      def serialize(*)
+        raise "uh oh, serialize failed!"
+      end
+    end
+
+    expect { JobClass.perform_later }.to raise_error(RuntimeError, "uh oh, serialize failed!")
+  end
+
+  it 'bubbles out an error if Delayed::Job.enqueue fails' do
+    allow(Delayed::Job).to receive(:enqueue).and_raise("uh oh, enqueue failed!")
+
+    expect { JobClass.perform_later }.to raise_error(RuntimeError, "uh oh, enqueue failed!")
+  end
+
   it 'deserializes even if the underlying job class is not defined' do
     JobClass.perform_later
 


### PR DESCRIPTION
@medlefsen noticed that [ActiveJob states this in their docs](https://apidock.com/rails/ActiveJob/Enqueuing/ClassMethods/perform_later) w.r.t. `perform_later`:

> Returns an instance of the job class queued with arguments available in Job#arguments or false if the enqueue did not succeed.

Since silently returning `false` would appear to conflict with our preference for guaranteeing message delivery, I'm adding a couple regression test cases to make more explicit the current behavior, which presumably is specific to the AJ backend.

The `delayed` backend will not return `false` from `perform_later`, and will instead bubble out an exception.

/no-platform