### PR TITLE
refactor: Drop support for Delayed::Worker.delay_jobs

### DIFF
--- a/app/models/delayed/job.rb
+++ b/app/models/delayed/job.rb
@@ -273,7 +273,7 @@ module Delayed
     end
 
     def run_time_alert?
-      alert_run_time&.<= run_time if run_time # locked_at may be `nil` if `delay_jobs` is false
+      alert_run_time&.<= run_time if run_time
     end
 
     def attempts_alert?

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -16,7 +16,7 @@ module Delayed
           new(options).tap do |job|
             Delayed.lifecycle.run_callbacks(:enqueue, job) do
               job.hook(:enqueue)
-              Delayed::Worker.delay_job?(job) ? job.save : job.invoke_job
+              job.save
             end
           end
         end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -17,7 +17,6 @@ module Delayed
     cattr_accessor :max_claims, instance_writer: false, default: 5
     cattr_accessor :max_run_time, instance_writer: false, default: 20.minutes
     cattr_accessor :default_priority, instance_writer: false, default: 10
-    cattr_accessor :delay_jobs, instance_writer: false, default: true
     cattr_accessor :queues, instance_writer: false, default: [].freeze
     cattr_accessor :read_ahead, instance_writer: false, default: 5
     cattr_accessor :destroy_failed_jobs, instance_writer: false, default: false
@@ -35,14 +34,6 @@ module Delayed
     class << self
       delegate :lifecycle, :plugins, :plugins=, :logger, :logger=,
                :default_log_level, :default_log_level=, to: Delayed
-    end
-
-    def self.delay_job?(job)
-      if delay_jobs.is_a?(Proc)
-        delay_jobs.arity == 1 ? delay_jobs.call(job) : delay_jobs.call
-      else
-        delay_jobs
-      end
     end
 
     def initialize

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -12,7 +12,6 @@ describe Delayed::Job do
     Delayed::Worker.min_priority = nil
     Delayed::Worker.max_claims = 1 # disable multithreading because SimpleJob is not threadsafe
     Delayed::Worker.default_priority = 99
-    Delayed::Worker.delay_jobs = true
     Delayed::Worker.deny_stale_enqueues = false
     Delayed::Worker.default_queue_name = 'default_tracking'
     SimpleJob.runs = 0
@@ -111,27 +110,6 @@ describe Delayed::Job do
         options = { priority: 1 }
         described_class.enqueue SimpleJob.new, options
         expect(options).to eq(priority: 1)
-      end
-    end
-
-    context 'with delay_jobs = false' do
-      before(:each) do
-        Delayed::Worker.delay_jobs = false
-      end
-
-      it 'does not increase count after enqueuing items' do
-        described_class.enqueue SimpleJob.new
-        expect(described_class.count).to eq(0)
-      end
-
-      it 'invokes the enqueued job' do
-        job = SimpleJob.new
-        expect(job).to receive(:perform)
-        described_class.enqueue job
-      end
-
-      it 'returns a job, not the result of invocation' do
-        expect(described_class.enqueue(SimpleJob.new)).to be_instance_of(described_class)
       end
     end
 
@@ -1177,7 +1155,7 @@ describe Delayed::Job do
       expect(subject.run_time_alert?).to eq(false)
     end
 
-    context 'when the job is not locked (e.g. delay_jobs is false)' do
+    context 'when the job is not locked' do
       let(:locked_at) { nil }
 
       it 'returns nil' do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -143,7 +143,6 @@ RSpec.configure do |config|
     aj_queue_name_was = ActiveJob::Base.queue_name
     default_priority_was = Delayed::Worker.default_priority
     default_queue_name_was = Delayed::Worker.default_queue_name
-    delay_jobs_was = Delayed::Worker.delay_jobs
     destroy_failed_jobs_was = Delayed::Worker.destroy_failed_jobs
     max_attempts_was = Delayed::Worker.max_attempts
     max_claims_was = Delayed::Worker.max_claims
@@ -165,7 +164,6 @@ RSpec.configure do |config|
     ActiveJob::Base.queue_name = aj_queue_name_was
     Delayed::Worker.default_priority = default_priority_was
     Delayed::Worker.default_queue_name = default_queue_name_was
-    Delayed::Worker.delay_jobs = delay_jobs_was
     Delayed::Worker.destroy_failed_jobs = destroy_failed_jobs_was
     Delayed::Worker.max_attempts = max_attempts_was
     Delayed::Worker.max_claims = max_claims_was

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -116,44 +116,13 @@ describe Delayed::MessageSending do
       expect(job.priority).to eq(20)
     end
 
-    it 'does not delay the job when delay_jobs is false' do
-      Delayed::Worker.delay_jobs = false
-      fairy_tail = FairyTail.new
-      expect {
-        expect {
-          fairy_tail.delay.tell('a', kwarg: 'b')
-        }.to change { fairy_tail.happy_ending }.from(nil).to %w(a b)
-      }.not_to(change { Delayed::Job.count })
-    end
-
-    it 'does delay the job when delay_jobs is true' do
-      Delayed::Worker.delay_jobs = true
+    it 'delays the job' do
       fairy_tail = FairyTail.new
       expect {
         expect {
           fairy_tail.delay.tell('a', kwarg: 'b')
         }.not_to change { fairy_tail.happy_ending }
       }.to change { Delayed::Job.count }.by(1)
-    end
-
-    it 'does delay when delay_jobs is a proc returning true' do
-      Delayed::Worker.delay_jobs = ->(_job) { true }
-      fairy_tail = FairyTail.new
-      expect {
-        expect {
-          fairy_tail.delay.tell('a', kwarg: 'b')
-        }.not_to change { fairy_tail.happy_ending }
-      }.to change { Delayed::Job.count }.by(1)
-    end
-
-    it 'does not delay the job when delay_jobs is a proc returning false' do
-      Delayed::Worker.delay_jobs = ->(_job) { false }
-      fairy_tail = FairyTail.new
-      expect {
-        expect {
-          fairy_tail.delay.tell('a', kwarg: 'b')
-        }.to change { fairy_tail.happy_ending }.from(nil).to %w(a b)
-      }.not_to(change { Delayed::Job.count })
     end
   end
 end

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -113,36 +113,5 @@ describe Delayed::PerformableMethod do
       expect(method.object).to receive(:failure)
       method.failure
     end
-
-    context 'with delay_job == false' do
-      before do
-        Delayed::Worker.delay_jobs = false
-      end
-
-      after do
-        Delayed::Worker.delay_jobs = true
-      end
-
-      %w(before after success).each do |hook|
-        it "delegates #{hook} hook to object" do
-          story = Story.create
-          expect(story).to receive(hook).with(an_instance_of(Delayed::Job))
-          story.delay.tell
-        end
-      end
-
-      it 'delegates error hook to object' do
-        story = Story.create
-        expect(story).to receive(:error).with(an_instance_of(Delayed::Job), an_instance_of(RuntimeError))
-        expect(story).to receive(:tell).and_raise(RuntimeError)
-        expect { story.delay.tell }.to raise_error(RuntimeError)
-      end
-
-      it 'delegates failure hook to object' do
-        method = described_class.new('object', :size, [], {})
-        expect(method.object).to receive(:failure)
-        method.failure
-      end
-    end
   end
 end


### PR DESCRIPTION
Removes the `delay_jobs` config (and `delay_job?` helper) that allowed enqueues to run inline instead of persisting a job. Enqueue now always saves. Also drops the corresponding spec coverage and helper reset.

This is effort of persisting all jobs via `enqueue_all` in the next major version bump, which inherently uses insert_all under the hood(ie: always enqueues).

cc @effron @smudge 