### PR TITLE
refactor: deprecate :enqueue job hook

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -14,8 +14,8 @@ module Delayed
 
         def enqueue_job(options)
           new(options).tap do |job|
+            warn_deprecated_enqueue_hook(job.payload_object)
             Delayed.lifecycle.run_callbacks(:enqueue, job) do
-              job.hook(:enqueue)
               Delayed::Worker.delay_job?(job) ? job.save : job.invoke_job
             end
           end
@@ -44,6 +44,15 @@ module Delayed
 
         def name_assignable?
           column_names.include?('name')
+        end
+
+        private
+
+        def warn_deprecated_enqueue_hook(payload)
+          return if payload.is_a?(Delayed::JobWrapper)
+          return unless payload.respond_to?(:enqueue)
+
+          warn "[DEPRECATION] :enqueue hook on #{payload.class} is deprecated and is no longer invoked"
         end
       end
 
@@ -109,9 +118,12 @@ module Delayed
 
       def hook(name, *args)
         if payload_object.respond_to?(name)
-          if payload_object.is_a?(Delayed::JobWrapper)
-            return if name == :enqueue # this callback is not supported due to method naming conflicts.
+          if name == :enqueue
+            warn '[DEPRECATION] :enqueue hook is deprecated'
+            return
+          end
 
+          if payload_object.is_a?(Delayed::JobWrapper)
             warn '[DEPRECATION] Job hook methods (`before`, `after`, `success`, etc) are deprecated. Use ActiveJob callbacks instead.'
           end
 

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -14,7 +14,7 @@ module Delayed
 
         def enqueue_job(options)
           new(options).tap do |job|
-            warn_deprecated_enqueue_hook(job.payload_object)
+            raise_deprecated_enqueue_hook(job.payload_object)
             Delayed.lifecycle.run_callbacks(:enqueue, job) do
               Delayed::Worker.delay_job?(job) ? job.save : job.invoke_job
             end
@@ -48,11 +48,11 @@ module Delayed
 
         private
 
-        def warn_deprecated_enqueue_hook(payload)
+        def raise_deprecated_enqueue_hook(payload)
           return if payload.is_a?(Delayed::JobWrapper)
           return unless payload.respond_to?(:enqueue)
 
-          warn "[DEPRECATION] :enqueue hook on #{payload.class} is deprecated and is no longer invoked"
+          raise ":enqueue hook on #{payload.class} is no longer supported"
         end
       end
 
@@ -119,8 +119,7 @@ module Delayed
       def hook(name, *args)
         if payload_object.respond_to?(name)
           if name == :enqueue
-            warn '[DEPRECATION] :enqueue hook is deprecated'
-            return
+            raise ':enqueue hook is no longer supported'
           end
 
           if payload_object.is_a?(Delayed::JobWrapper)

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -37,12 +37,6 @@ describe Delayed::Job do
   end
 
   describe 'enqueue' do
-    it "allows enqueue hook to modify job at DB level" do
-      later = described_class.db_time_now + 20.minutes
-      job = described_class.enqueue payload_object: EnqueueJobMod.new
-      expect(described_class.find(job.id).run_at).to be_within(1).of(later)
-    end
-
     context 'with a hash' do
       it "raises ArgumentError when handler doesn't respond_to :perform" do
         expect { described_class.enqueue(payload_object: Object.new) }.to raise_error(ArgumentError)
@@ -170,6 +164,42 @@ describe Delayed::Job do
         expect(job).to be_persisted
       end
     end
+
+    context 'when payload defines a deprecated :enqueue hook' do
+      before do
+        stub_const('JobWithEnqueueHook', Class.new do
+          def enqueue(_job); end
+
+          def perform; end
+        end)
+      end
+
+      it 'emits a deprecation warning naming the payload class' do
+        expect { described_class.enqueue(JobWithEnqueueHook.new) }
+          .to output(/\[DEPRECATION\] :enqueue hook on JobWithEnqueueHook/).to_stderr
+      end
+
+      it 'does not invoke the payload enqueue method' do
+        payload = JobWithEnqueueHook.new
+        expect(payload).not_to receive(:enqueue)
+        expect { described_class.enqueue(payload) }.to output(/DEPRECATION/).to_stderr
+      end
+    end
+
+    context 'when payload does not define :enqueue' do
+      it 'does not emit a deprecation warning' do
+        expect { described_class.enqueue(SimpleJob.new) }
+          .not_to output(/\[DEPRECATION\] :enqueue hook/).to_stderr
+      end
+    end
+
+    context 'when payload is an ActiveJob wrapper that responds to :enqueue' do
+      it 'does not emit the deprecation warning' do
+        wrapper = ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(ActiveJobJob.new.serialize)
+        expect { described_class.enqueue(payload_object: wrapper) }
+          .not_to output(/\[DEPRECATION\] :enqueue hook/).to_stderr
+      end
+    end
   end
 
   describe 'callbacks' do
@@ -187,9 +217,9 @@ describe Delayed::Job do
 
     it 'calls before and after callbacks' do
       job = described_class.enqueue(CallbackJob.new)
-      expect(CallbackJob.messages).to eq(['enqueue'])
+      expect(CallbackJob.messages).to eq([])
       job.invoke_job
-      expect(CallbackJob.messages).to eq(%w(enqueue before perform success after))
+      expect(CallbackJob.messages).to eq(%w(before perform success after))
     end
 
     it 'calls the after callback with an error' do
@@ -197,14 +227,14 @@ describe Delayed::Job do
       expect(job.payload_object).to receive(:perform).and_raise(RuntimeError.new('fail'))
 
       expect { job.invoke_job }.to raise_error(RuntimeError, 'fail')
-      expect(CallbackJob.messages).to eq(['enqueue', 'before', 'error: RuntimeError', 'after'])
+      expect(CallbackJob.messages).to eq(['before', 'error: RuntimeError', 'after'])
     end
 
     it 'calls error when before raises an error' do
       job = described_class.enqueue(CallbackJob.new)
       expect(job.payload_object).to receive(:before).and_raise(RuntimeError.new('fail'))
       expect { job.invoke_job }.to raise_error(RuntimeError, 'fail')
-      expect(CallbackJob.messages).to eq(['enqueue', 'error: RuntimeError', 'after'])
+      expect(CallbackJob.messages).to eq(['error: RuntimeError', 'after'])
     end
   end
 

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -165,7 +165,7 @@ describe Delayed::Job do
       end
     end
 
-    context 'when payload defines a deprecated :enqueue hook' do
+    context 'when payload defines an :enqueue hook' do
       before do
         stub_const('JobWithEnqueueHook', Class.new do
           def enqueue(_job); end
@@ -174,30 +174,47 @@ describe Delayed::Job do
         end)
       end
 
-      it 'emits a deprecation warning naming the payload class' do
+      it 'raises an error naming the payload class' do
         expect { described_class.enqueue(JobWithEnqueueHook.new) }
-          .to output(/\[DEPRECATION\] :enqueue hook on JobWithEnqueueHook/).to_stderr
+          .to raise_error(RuntimeError, ':enqueue hook on JobWithEnqueueHook is no longer supported')
       end
 
       it 'does not invoke the payload enqueue method' do
         payload = JobWithEnqueueHook.new
         expect(payload).not_to receive(:enqueue)
-        expect { described_class.enqueue(payload) }.to output(/DEPRECATION/).to_stderr
+        expect { described_class.enqueue(payload) }.to raise_error(RuntimeError, /:enqueue hook/)
       end
     end
 
     context 'when payload does not define :enqueue' do
-      it 'does not emit a deprecation warning' do
-        expect { described_class.enqueue(SimpleJob.new) }
-          .not_to output(/\[DEPRECATION\] :enqueue hook/).to_stderr
+      it 'does not raise' do
+        expect { described_class.enqueue(SimpleJob.new) }.not_to raise_error
       end
     end
 
     context 'when payload is an ActiveJob wrapper that responds to :enqueue' do
-      it 'does not emit the deprecation warning' do
+      it 'does not raise' do
         wrapper = ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(ActiveJobJob.new.serialize)
-        expect { described_class.enqueue(payload_object: wrapper) }
-          .not_to output(/\[DEPRECATION\] :enqueue hook/).to_stderr
+        expect { described_class.enqueue(payload_object: wrapper) }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#hook' do
+    context 'with :enqueue' do
+      before do
+        stub_const('JobWithEnqueueHook', Class.new do
+          def enqueue(_job); end
+
+          def perform; end
+        end)
+      end
+
+      it 'raises rather than invoking the payload hook' do
+        job = described_class.new(payload_object: JobWithEnqueueHook.new)
+        expect(job.payload_object).not_to receive(:enqueue)
+        expect { job.hook(:enqueue) }
+          .to raise_error(RuntimeError, ':enqueue hook is no longer supported')
       end
     end
   end

--- a/spec/performable_method_spec.rb
+++ b/spec/performable_method_spec.rb
@@ -95,12 +95,6 @@ describe Delayed::PerformableMethod do
       end
     end
 
-    it 'delegates enqueue hook to object' do
-      story = Story.create
-      expect(story).to receive(:enqueue).with(an_instance_of(Delayed::Job))
-      story.delay.tell
-    end
-
     it 'delegates error hook to object' do
       story = Story.create
       expect(story).to receive(:error).with(an_instance_of(Delayed::Job), an_instance_of(RuntimeError))

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -77,10 +77,6 @@ end
 class CallbackJob
   cattr_accessor :messages
 
-  def enqueue(_job)
-    self.class.messages << 'enqueue'
-  end
-
   def before(_job)
     self.class.messages << 'before'
   end
@@ -103,12 +99,6 @@ class CallbackJob
 
   def failure(_job)
     self.class.messages << 'failure'
-  end
-end
-
-class EnqueueJobMod < SimpleJob
-  def enqueue(job)
-    job.run_at = 20.minutes.from_now
   end
 end
 


### PR DESCRIPTION
Remove the job.hook(:enqueue) invocation from enqueue_job so payloads can no longer mutate or observe the job at enqueue time. The hook method now short-circuits on :enqueue with a deprecation warning for any direct callers, and enqueue_job emits its own deprecation warning (naming the payload class) when a non-ActiveJob payload still defines :enqueue, so users discover the broken hook at enqueue time rather than silently.

Drop tests and sample jobs that existed only to exercise the hook (EnqueueJobMod, CallbackJob#enqueue, PerformableMethod's enqueue delegation spec) and remove the 'enqueue' message expectations from the remaining callback tests. Add specs covering the new warn paths, including the regression guard that ActiveJob JobWrapper payloads do not trigger the deprecation warning.

cc @effron @smudge 