### PR TITLE
refactor: Drop support for Delayed::Worker.delay_jobs being proc

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -16,7 +16,7 @@ module Delayed
           new(options).tap do |job|
             Delayed.lifecycle.run_callbacks(:enqueue, job) do
               job.hook(:enqueue)
-              Delayed::Worker.delay_job? ? job.save : job.invoke_job
+              Delayed::Worker.delay_jobs ? job.save : job.invoke_job
             end
           end
         end

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -16,7 +16,7 @@ module Delayed
           new(options).tap do |job|
             Delayed.lifecycle.run_callbacks(:enqueue, job) do
               job.hook(:enqueue)
-              Delayed::Worker.delay_job?(job) ? job.save : job.invoke_job
+              Delayed::Worker.delay_job? ? job.save : job.invoke_job
             end
           end
         end

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -16,6 +16,8 @@ module Delayed
           new(options).tap do |job|
             Delayed.lifecycle.run_callbacks(:enqueue, job) do
               job.hook(:enqueue)
+              raise 'Delayed::Worker.delay_jobs may not be a Proc' if Delayed::Worker.delay_jobs.is_a?(Proc)
+
               Delayed::Worker.delay_jobs ? job.save : job.invoke_job
             end
           end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -37,9 +37,14 @@ module Delayed
                :default_log_level, :default_log_level=, to: Delayed
     end
 
-    def self.delay_job?(job)
+    def self.delay_job?
       if delay_jobs.is_a?(Proc)
-        delay_jobs.arity == 1 ? delay_jobs.call(job) : delay_jobs.call
+        if delay_jobs.arity.positive?
+          warn '[DEPRECATION] delay_jobs proc arity 1 support is deprecated and behaves as delay_jobs=true'
+          true
+        else
+          delay_jobs.call
+        end
       else
         delay_jobs
       end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -37,19 +37,6 @@ module Delayed
                :default_log_level, :default_log_level=, to: Delayed
     end
 
-    def self.delay_job?
-      if delay_jobs.is_a?(Proc)
-        if delay_jobs.arity.positive?
-          warn '[DEPRECATION] delay_jobs proc arity 1 support is deprecated and behaves as delay_jobs=true'
-          true
-        else
-          delay_jobs.call
-        end
-      else
-        delay_jobs
-      end
-    end
-
     def initialize
       @failed_reserve_count = 0
 

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -137,7 +137,7 @@ describe Delayed::MessageSending do
     end
 
     it 'does delay when delay_jobs is a proc returning true' do
-      Delayed::Worker.delay_jobs = ->(_job) { true }
+      Delayed::Worker.delay_jobs = -> { true }
       fairy_tail = FairyTail.new
       expect {
         expect {
@@ -147,13 +147,25 @@ describe Delayed::MessageSending do
     end
 
     it 'does not delay the job when delay_jobs is a proc returning false' do
-      Delayed::Worker.delay_jobs = ->(_job) { false }
+      Delayed::Worker.delay_jobs = -> { false }
       fairy_tail = FairyTail.new
       expect {
         expect {
           fairy_tail.delay.tell('a', kwarg: 'b')
         }.to change { fairy_tail.happy_ending }.from(nil).to %w(a b)
       }.not_to(change { Delayed::Job.count })
+    end
+
+    it 'warns and behaves as delay_jobs=true when delay_jobs is a proc with arity 1' do
+      Delayed::Worker.delay_jobs = ->(_job) { false }
+      fairy_tail = FairyTail.new
+      expect {
+        expect {
+          expect {
+            fairy_tail.delay.tell('a', kwarg: 'b')
+          }.not_to change { fairy_tail.happy_ending }
+        }.to change { Delayed::Job.count }.by(1)
+      }.to output(/\[DEPRECATION\] delay_jobs proc arity 1 support is deprecated/).to_stderr
     end
   end
 end

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -135,37 +135,5 @@ describe Delayed::MessageSending do
         }.not_to change { fairy_tail.happy_ending }
       }.to change { Delayed::Job.count }.by(1)
     end
-
-    it 'does delay when delay_jobs is a proc returning true' do
-      Delayed::Worker.delay_jobs = -> { true }
-      fairy_tail = FairyTail.new
-      expect {
-        expect {
-          fairy_tail.delay.tell('a', kwarg: 'b')
-        }.not_to change { fairy_tail.happy_ending }
-      }.to change { Delayed::Job.count }.by(1)
-    end
-
-    it 'does not delay the job when delay_jobs is a proc returning false' do
-      Delayed::Worker.delay_jobs = -> { false }
-      fairy_tail = FairyTail.new
-      expect {
-        expect {
-          fairy_tail.delay.tell('a', kwarg: 'b')
-        }.to change { fairy_tail.happy_ending }.from(nil).to %w(a b)
-      }.not_to(change { Delayed::Job.count })
-    end
-
-    it 'warns and behaves as delay_jobs=true when delay_jobs is a proc with arity 1' do
-      Delayed::Worker.delay_jobs = ->(_job) { false }
-      fairy_tail = FairyTail.new
-      expect {
-        expect {
-          expect {
-            fairy_tail.delay.tell('a', kwarg: 'b')
-          }.not_to change { fairy_tail.happy_ending }
-        }.to change { Delayed::Job.count }.by(1)
-      }.to output(/\[DEPRECATION\] delay_jobs proc arity 1 support is deprecated/).to_stderr
-    end
   end
 end

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -135,5 +135,15 @@ describe Delayed::MessageSending do
         }.not_to change { fairy_tail.happy_ending }
       }.to change { Delayed::Job.count }.by(1)
     end
+
+    it 'raises when delay_jobs is a Proc' do
+      Delayed::Worker.delay_jobs = -> { true }
+      fairy_tail = FairyTail.new
+      expect {
+        expect {
+          fairy_tail.delay.tell('a', kwarg: 'b')
+        }.to raise_error('Delayed::Worker.delay_jobs may not be a Proc')
+      }.not_to(change { Delayed::Job.count })
+    end
   end
 end


### PR DESCRIPTION
After talking more with @effron and @smudge, this plan will replace https://github.com/Betterment/delayed/pull/105. In the short term, this makes the breaking change less breaking so that we can prepare for a full removal of `Delayed::Worker.delay_jobs` in the future.