### PR TITLE
refactor: Drop support for Delayed::Worker.delay_jobs being proc

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -16,7 +16,9 @@ module Delayed
           new(options).tap do |job|
             raise_deprecated_enqueue_hook(job.payload_object)
             Delayed.lifecycle.run_callbacks(:enqueue, job) do
-              Delayed::Worker.delay_job?(job) ? job.save : job.invoke_job
+              raise 'Delayed::Worker.delay_jobs may not be a Proc' if Delayed::Worker.delay_jobs.is_a?(Proc)
+
+              Delayed::Worker.delay_jobs ? job.save : job.invoke_job
             end
           end
         end

--- a/lib/delayed/worker.rb
+++ b/lib/delayed/worker.rb
@@ -37,14 +37,6 @@ module Delayed
                :default_log_level, :default_log_level=, to: Delayed
     end
 
-    def self.delay_job?(job)
-      if delay_jobs.is_a?(Proc)
-        delay_jobs.arity == 1 ? delay_jobs.call(job) : delay_jobs.call
-      else
-        delay_jobs
-      end
-    end
-
     def initialize
       @failed_reserve_count = 0
 

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -136,23 +136,13 @@ describe Delayed::MessageSending do
       }.to change { Delayed::Job.count }.by(1)
     end
 
-    it 'does delay when delay_jobs is a proc returning true' do
-      Delayed::Worker.delay_jobs = ->(_job) { true }
+    it 'raises when delay_jobs is a Proc' do
+      Delayed::Worker.delay_jobs = -> { true }
       fairy_tail = FairyTail.new
       expect {
         expect {
           fairy_tail.delay.tell('a', kwarg: 'b')
-        }.not_to change { fairy_tail.happy_ending }
-      }.to change { Delayed::Job.count }.by(1)
-    end
-
-    it 'does not delay the job when delay_jobs is a proc returning false' do
-      Delayed::Worker.delay_jobs = ->(_job) { false }
-      fairy_tail = FairyTail.new
-      expect {
-        expect {
-          fairy_tail.delay.tell('a', kwarg: 'b')
-        }.to change { fairy_tail.happy_ending }.from(nil).to %w(a b)
+        }.to raise_error('Delayed::Worker.delay_jobs may not be a Proc')
       }.not_to(change { Delayed::Job.count })
     end
   end


### PR DESCRIPTION
Replacement for https://github.com/Betterment/delayed/pull/107 since I forgot to fork the repo before developing.