### PR TITLE
fix: switch aj adapter to pipe through enqueue_all

### DIFF
--- a/lib/delayed/active_job_adapter.rb
+++ b/lib/delayed/active_job_adapter.rb
@@ -31,20 +31,14 @@ module Delayed
     private
 
     def _enqueue(job)
-      assert_job_safe_to_enqueue!(job)
-      job_options = build_job_options(job)
-      delayed_job = Delayed::Job.enqueue_job(job_options)
-      perform_post_enqueue_assignments([job], [delayed_job])
-      job
+      job.tap { |j| enqueue_all([j]) }
     end
 
     def assert_jobs_safe_to_enqueue!(jobs)
-      jobs.each { |job| assert_job_safe_to_enqueue!(job) }
-    end
-
-    def assert_job_safe_to_enqueue!(job)
-      if enqueue_after_transaction_commit_enabled?(job)
-        raise UnsafeEnqueueError, "The ':delayed' ActiveJob adapter is not compatible with enqueue_after_transaction_commit"
+      jobs.each do |job|
+        if enqueue_after_transaction_commit_enabled?(job)
+          raise UnsafeEnqueueError, "The ':delayed' ActiveJob adapter is not compatible with enqueue_after_transaction_commit"
+        end
       end
     end
 

--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Delayed::ActiveJobAdapter do
   end
 
   it 'bubbles out an error if Delayed::Job.enqueue_job raises (single-job path)' do
-    allow(Delayed::Job).to receive(:enqueue_job).and_raise('uh oh, enqueue failed!')
+    allow(Delayed::Job).to receive(:enqueue_all).and_raise('uh oh, enqueue failed!')
 
     expect { JobClass.perform_later }.to raise_error(RuntimeError, 'uh oh, enqueue failed!')
   end
@@ -590,14 +590,14 @@ RSpec.describe Delayed::ActiveJobAdapter do
     end
   end
 
-  describe 'single-job perform_later routes through Delayed::Job.enqueue_job' do
-    it 'invokes Delayed::Job.enqueue_job (not Delayed::Job.enqueue or Delayed::Job.enqueue_all)' do
+  describe 'single-job perform_later routes through Delayed::Job.enqueue_all' do
+    it 'invokes Delayed::Job.enqueue_all (not Delayed::Job.enqueue or Delayed::Job.enqueue_job)' do
       expect(Delayed::Job).not_to receive(:enqueue) # rubocop:disable RSpec/MessageSpies
-      expect(Delayed::Job).not_to receive(:enqueue_all) # rubocop:disable RSpec/MessageSpies
+      expect(Delayed::Job).not_to receive(:enqueue_job) # rubocop:disable RSpec/MessageSpies
 
       JobClass.perform_later
 
-      expect(Delayed::Job).to have_received(:enqueue_job).once
+      expect(Delayed::Job).to have_received(:enqueue_all).once
     end
 
     it 'delegates exactly one Delayed::Job' do


### PR DESCRIPTION
Adjusts the ActiveJob adapter to pipe all enqueues through enqueue_all. Result of convo here: https://github.com/Betterment/delayed/pull/103#discussion_r3335987931

Note for release: This is a mildly breaking change. Previous to delayed 3.0.0, a `provider_job_id` was _always_ attached when enqueuing jobs. In delayed 3.0.0, `provider_job_id` will only be attached depending on your database configuration(specifically `ActiveRecord::Base.connection.supports_insert_returning?` must be true)