### PR TITLE
fix: README to reflect accurate enqueue lifecycle shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,7 @@ The following events will be emitted automatically by workers as jobs are reserv
 - **delayed.worker.reserve_jobs** - an event measuring the duration of the job "pickup query"
 
 The "run", "error", and "failure" events will include a `:job` argument in the event's payload,
-providing access to the job instance. The "enqueue" event will include a `:jobs` array (along with a
-`:count`) — note that elements may be either `Delayed::Job` instances (when enqueued directly via
-`Delayed::Job.enqueue`) or `ActiveJob` instances (when enqueued via `perform_later` / `perform_all_later`).
+providing access to the job instance. The "enqueue" event will include a `:jobs` array.
 
 ```ruby
 ActiveSupport::Notifications.subscribe('delayed.job.run') do |*args|

--- a/lib/delayed/active_job_adapter.rb
+++ b/lib/delayed/active_job_adapter.rb
@@ -43,16 +43,12 @@ module Delayed
     end
 
     def build_delayed_job(job)
-      prepared = build_job_options(job)
-      Delayed::Job.new(prepared)
-    end
-
-    def build_job_options(job)
       opts = { queue: job.queue_name, priority: job.priority }.compact
       opts.merge!(job.provider_attributes || {})
       opts[:run_at] = coerce_scheduled_at(job.scheduled_at) if job.scheduled_at
 
-      Delayed::Backend::JobPreparer.new(JobWrapper.new(job), opts).prepare
+      prepared = Delayed::Backend::JobPreparer.new(JobWrapper.new(job), opts).prepare
+      Delayed::Job.new(prepared)
     end
 
     def perform_post_enqueue_assignments(active_jobs, delayed_jobs)


### PR DESCRIPTION
- Fixes README to properly reflect the `enqueue` lifecycle event
- Refactors unnecessary method nesting in the AJ adapter.