### PR TITLE
fix: Assert ActiveJobs can not be passed directly to DJ enqueue methods without going through the adapter

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -82,7 +82,7 @@ module Delayed
         end
 
         def assert_no_enqueue_hook!(payload)
-          return if payload.is_a?(Delayed::JobWrapper)
+          return if payload.is_a?(Delayed::JobWrapper) || payload.is_a?(ActiveJob::Base)
           return unless payload.respond_to?(:enqueue)
 
           raise ":enqueue hook on #{payload.class} is no longer supported"

--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -14,6 +14,7 @@ module Delayed
 
         def enqueue_job(options)
           new(options).tap do |job|
+            assert_payload_not_active_job!(job.payload_object)
             assert_no_enqueue_hook!(job.payload_object)
             assert_delay_jobs_not_proc!
 
@@ -29,7 +30,10 @@ module Delayed
         def enqueue_all(jobs)
           return 0 if jobs.empty?
 
-          jobs.each { |job| assert_no_enqueue_hook!(job.payload_object) }
+          jobs.each do |job|
+            assert_payload_not_active_job!(job.payload_object)
+            assert_no_enqueue_hook!(job.payload_object)
+          end
           assert_delay_jobs_not_proc!
 
           Delayed.lifecycle.run_callbacks(:enqueue, jobs) do
@@ -81,8 +85,12 @@ module Delayed
           jobs.zip(ids) { |job, id| job.id = id }
         end
 
+        def assert_payload_not_active_job!(payload)
+          raise "Delayed::Job enqueue methods do not accept ActiveJobs, use perform_later instead" if payload.is_a?(ActiveJob::Base)
+        end
+
         def assert_no_enqueue_hook!(payload)
-          return if payload.is_a?(Delayed::JobWrapper) || payload.is_a?(ActiveJob::Base)
+          return if payload.is_a?(Delayed::JobWrapper)
           return unless payload.respond_to?(:enqueue)
 
           raise ":enqueue hook on #{payload.class} is no longer supported"

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -210,6 +210,18 @@ describe Delayed::Job do
         described_class.enqueue(payload_object: payload)
       end
     end
+
+    context 'when passed a bare ActiveJob::Base instance' do
+      it 'does not raise' do
+        expect { described_class.enqueue(ActiveJobJob.new) }.not_to raise_error
+      end
+
+      it 'does not invoke the ActiveJob :enqueue method' do
+        job = ActiveJobJob.new
+        expect(job).not_to receive(:enqueue)
+        described_class.enqueue(job)
+      end
+    end
   end
 
   describe '.enqueue_all' do

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -200,26 +200,14 @@ describe Delayed::Job do
     end
 
     context 'when payload is a bare ActiveJob::Base instance' do
-      it 'does not raise' do
-        expect { described_class.enqueue(payload_object: ActiveJobJob.new) }.not_to raise_error
-      end
-
-      it 'does not invoke the ActiveJob :enqueue method' do
-        payload = ActiveJobJob.new
-        expect(payload).not_to receive(:enqueue)
-        described_class.enqueue(payload_object: payload)
+      it 'raises' do
+        expect { described_class.enqueue(payload_object: ActiveJobJob.new) }.to raise_error(RuntimeError, /Delayed::Job enqueue methods do not accept ActiveJobs/)
       end
     end
 
     context 'when passed a bare ActiveJob::Base instance' do
-      it 'does not raise' do
-        expect { described_class.enqueue(ActiveJobJob.new) }.not_to raise_error
-      end
-
-      it 'does not invoke the ActiveJob :enqueue method' do
-        job = ActiveJobJob.new
-        expect(job).not_to receive(:enqueue)
-        described_class.enqueue(job)
+      it 'raises' do
+        expect { described_class.enqueue(ActiveJobJob.new) }.to raise_error(RuntimeError, /Delayed::Job enqueue methods do not accept ActiveJobs/)
       end
     end
   end
@@ -297,14 +285,9 @@ describe Delayed::Job do
     end
 
     context 'when a job payload is a bare ActiveJob::Base instance' do
-      it 'does not raise' do
+      it 'raises' do
         jobs = [build_job(ActiveJobJob.new)]
-        expect { described_class.enqueue_all(jobs) }.not_to raise_error
-      end
-
-      it 'inserts the job' do
-        jobs = [build_job(ActiveJobJob.new)]
-        expect { described_class.enqueue_all(jobs) }.to change { described_class.count }.by(1)
+        expect { described_class.enqueue_all(jobs) }.to raise_error(RuntimeError, /Delayed::Job enqueue methods do not accept ActiveJobs/)
       end
     end
   end

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -198,6 +198,18 @@ describe Delayed::Job do
         expect { described_class.enqueue(payload_object: wrapper) }.not_to raise_error
       end
     end
+
+    context 'when payload is a bare ActiveJob::Base instance' do
+      it 'does not raise' do
+        expect { described_class.enqueue(payload_object: ActiveJobJob.new) }.not_to raise_error
+      end
+
+      it 'does not invoke the ActiveJob :enqueue method' do
+        payload = ActiveJobJob.new
+        expect(payload).not_to receive(:enqueue)
+        described_class.enqueue(payload_object: payload)
+      end
+    end
   end
 
   describe '.enqueue_all' do
@@ -269,6 +281,18 @@ describe Delayed::Job do
         expect { described_class.enqueue_all(jobs) }
           .to raise_error(RuntimeError, ':enqueue hook on JobWithEnqueueHook is no longer supported')
         expect(described_class.count).to eq(0)
+      end
+    end
+
+    context 'when a job payload is a bare ActiveJob::Base instance' do
+      it 'does not raise' do
+        jobs = [build_job(ActiveJobJob.new)]
+        expect { described_class.enqueue_all(jobs) }.not_to raise_error
+      end
+
+      it 'inserts the job' do
+        jobs = [build_job(ActiveJobJob.new)]
+        expect { described_class.enqueue_all(jobs) }.to change { described_class.count }.by(1)
       end
     end
   end


### PR DESCRIPTION
Introduces new assertion that enforces that an ActiveJob cannot be passed into DJ enqueue methods, indicating to consumers that `perform_later` should be used instead in order to pipe through the adapter.