### PR TITLE
Define named priority methods as real methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    delayed (3.0.1)
+    delayed (3.1.0)
       activerecord (>= 6.0)
       concurrent-ruby
 

--- a/lib/delayed/priority.rb
+++ b/lib/delayed/priority.rb
@@ -70,11 +70,12 @@ module Delayed
       def names=(names)
         raise "must include a name for priority >= 0" if names && !names.value?(0)
 
+        remove_named_priority_methods
         @ranges = nil
         @alerts = nil
         @names_to_priority = nil
         @names = names&.sort_by(&:last)&.to_h&.transform_values { |v| new(v) }
-        redefine_named_priority_methods
+        define_named_priority_methods
       end
 
       def alerts=(alerts)
@@ -129,26 +130,30 @@ module Delayed
       # `priority.eventual?`) per name, as real, introspectable methods (visible to `methods`,
       # RDoc, and Sorbet's tapioca, unlike `method_missing` dispatch). Pre-existing methods
       # (e.g. a name of `superclass`) are never overridden.
-      def redefine_named_priority_methods
-        @named_priority_class_methods&.each { |m| singleton_class.send(:remove_method, m) }
-        @named_priority_predicates&.each { |m| remove_method(m) }
-        @named_priority_class_methods = names.keys.filter_map { |name| define_priority_class_method(name) }
-        @named_priority_predicates = names.keys.filter_map { |name| define_priority_predicate(name) }
+      def define_named_priority_methods
+        names.each_key do |name|
+          predicate = :"#{name}?"
+          define_singleton_method(name) { names_to_priority.fetch(name) } unless method_defined_on?(singleton_class, name)
+          define_method(predicate) { name.to_s == to_s } unless method_defined_on?(self, predicate)
+        end
       end
 
-      def define_priority_class_method(name)
-        return if singleton_class.method_defined?(name) || singleton_class.private_method_defined?(name)
-
-        define_singleton_method(name) { names_to_priority.fetch(name) }
-        name
+      # Removes the methods previously defined for the current `names` (called before `names` is
+      # reassigned). The non-inherited (`false`) checks mean we only remove methods we defined
+      # ourselves, leaving any pre-existing method a colliding name never overrode (e.g.
+      # `Class#superclass`, `Numeric#zero?`) in place.
+      def remove_named_priority_methods
+        names.each_key do |name|
+          predicate = :"#{name}?"
+          singleton_class.send(:remove_method, name) if singleton_class.method_defined?(name, false)
+          remove_method(predicate) if method_defined?(predicate, false)
+        end
       end
 
-      def define_priority_predicate(name)
-        predicate = :"#{name}?"
-        return if method_defined?(predicate) || private_method_defined?(predicate)
-
-        define_method(predicate) { name.to_s == to_s }
-        predicate
+      # Whether `mod` already responds to `name` (public, protected, private, or inherited), in
+      # which case a same-named priority must not override it.
+      def method_defined_on?(mod, name)
+        mod.method_defined?(name) || mod.private_method_defined?(name)
       end
     end
 
@@ -203,6 +208,6 @@ module Delayed
       to_i.to_d
     end
 
-    send(:redefine_named_priority_methods)
+    send(:define_named_priority_methods)
   end
 end

--- a/lib/delayed/priority.rb
+++ b/lib/delayed/priority.rb
@@ -74,6 +74,7 @@ module Delayed
         @alerts = nil
         @names_to_priority = nil
         @names = names&.sort_by(&:last)&.to_h&.transform_values { |v| new(v) }
+        redefine_named_priority_methods
       end
 
       def alerts=(alerts)
@@ -124,16 +125,30 @@ module Delayed
         low + ((high - low).to_d / 2).ceil
       end
 
-      def respond_to_missing?(method_name, include_private = false)
-        names_to_priority.key?(method_name) || super
+      # Defines a class method (e.g. `Priority.eventual`) and an instance predicate (e.g.
+      # `priority.eventual?`) per name, as real, introspectable methods (visible to `methods`,
+      # RDoc, and Sorbet's tapioca, unlike `method_missing` dispatch). Pre-existing methods
+      # (e.g. a name of `superclass`) are never overridden.
+      def redefine_named_priority_methods
+        @named_priority_class_methods&.each { |m| singleton_class.send(:remove_method, m) }
+        @named_priority_predicates&.each { |m| remove_method(m) }
+        @named_priority_class_methods = names.keys.filter_map { |name| define_priority_class_method(name) }
+        @named_priority_predicates = names.keys.filter_map { |name| define_priority_predicate(name) }
       end
 
-      def method_missing(method_name, *args)
-        if names_to_priority.key?(method_name) && args.none?
-          names_to_priority[method_name]
-        else
-          super
-        end
+      def define_priority_class_method(name)
+        return if singleton_class.method_defined?(name) || singleton_class.private_method_defined?(name)
+
+        define_singleton_method(name) { names_to_priority.fetch(name) }
+        name
+      end
+
+      def define_priority_predicate(name)
+        predicate = :"#{name}?"
+        return if method_defined?(predicate) || private_method_defined?(predicate)
+
+        define_method(predicate) { name.to_s == to_s }
+        predicate
       end
     end
 
@@ -188,18 +203,6 @@ module Delayed
       to_i.to_d
     end
 
-    private
-
-    def respond_to_missing?(method_name, include_private = false)
-      (method_name.to_s.end_with?('?') && self.class.names.key?(method_name.to_s[0..-2].to_sym)) || super
-    end
-
-    def method_missing(method_name, *args)
-      if method_name.to_s.end_with?('?') && self.class.names.key?(method_name.to_s[0..-2].to_sym)
-        method_name.to_s[0..-2] == to_s
-      else
-        super
-      end
-    end
+    send(:redefine_named_priority_methods)
   end
 end

--- a/lib/delayed/version.rb
+++ b/lib/delayed/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Delayed
-  VERSION = '3.0.1'
+  VERSION = '3.1.0'
 end

--- a/spec/delayed/priority_spec.rb
+++ b/spec/delayed/priority_spec.rb
@@ -13,9 +13,10 @@ RSpec.describe Delayed::Priority do
   ensure
     described_class.alerts = nil
     described_class.names = nil
+    described_class.assign_at_midpoint = nil
   end
 
-  describe '.names, .ranges, .alerts, .names_to_priority, method_missing' do
+  describe '.names, .ranges, .alerts, .names_to_priority, named priority methods' do
     it 'defaults to interactive, user_visible, eventual, reporting' do
       expect(described_class.names).to eq(
         interactive: 0,
@@ -65,6 +66,34 @@ RSpec.describe Delayed::Priority do
         expect(described_class.user_visible).to eq 15
         expect(described_class.eventual).to eq 25
         expect(described_class.reporting).to eq 35
+      end
+    end
+
+    it 'defines named priority methods as real, introspectable methods' do
+      expect(described_class.singleton_class.method_defined?(:eventual)).to be true
+      expect(described_class.method_defined?(:eventual?)).to be true
+    end
+
+    it 'removes methods for the old names when names are reassigned' do
+      described_class.names = { high: 0 }
+      expect(described_class).to respond_to(:high)
+      expect(described_class.new(0)).to be_high
+
+      described_class.names = nil
+      expect(described_class).not_to respond_to(:high)
+      expect(described_class.new(0)).not_to respond_to(:high?)
+      expect(described_class).to respond_to(:interactive)
+      expect(described_class.new(0)).to be_interactive
+    end
+
+    context 'when a name collides with an existing method' do
+      let(:custom_names) { { superclass: 0, zero: 10 } }
+
+      it 'does not redefine the existing method' do
+        expect(described_class.superclass).to eq Numeric # Class#superclass, not the priority
+        expect(described_class.new(0).zero?).to be true # Numeric#zero?, not the range predicate
+        expect(described_class.zero).to eq 10
+        expect(described_class.new(5).superclass?).to be true
       end
     end
 


### PR DESCRIPTION
## What

Replaces `method_missing` dispatch for named priority lookups with real method definitions:

- **Class methods** — `Delayed::Priority.eventual`, `.interactive`, etc.
- **Instance predicates** — `priority.eventual?`, `priority.interactive?`, etc.

Methods are defined when the class loads (for the default names) and are removed/redefined whenever `Delayed::Priority.names=` is assigned. Bodies still resolve through `names_to_priority` at call time, so `assign_at_midpoint` behavior is unchanged.

## Why

`method_missing` methods are invisible to runtime reflection, so RDoc and Sorbet's tapioca can't see them. In practice this means every Sorbet-adopting app hits errors like:

```
Method eventual does not exist on T.class_of(Delayed::Priority) https://srb.help/7003
```

on every `queue_with_priority Delayed::Priority.eventual` call site, and has to hand-maintain a shim RBI. (In Betterment's retail monorepo this single pattern is currently the only thing blocking ~95 files from `typed: true`.) With real definitions, `tapioca gems` picks the methods up automatically:

```ruby
Delayed::Priority.methods(false)
# => [..., :eventual, :interactive, :reporting, :user_visible, ...]
```

## Behavior notes

- **Pre-existing methods are never overridden.** Under `method_missing`, a real method always won (e.g. a hypothetical name of `superclass` would never shadow `Class#superclass`); the new definitions skip any name/predicate that already resolves, preserving that exactly. Covered by a new spec.
- **`respond_to?` semantics are unchanged**, including `respond_to?(:interactive) == false` after names are customized (existing specs cover this).
- Apps that customize `names=` in an initializer still won't see their custom names in a tapioca-generated gem RBI (tapioca doesn't boot the app) — same as today; they keep their shims.

## Also

Fixes a pre-existing test-order leak in `priority_spec.rb`: the `around` hook reset `names` and `alerts` but not `assign_at_midpoint`, so any spec running after a midpoint example observed midpoint-shifted values. Reproducible on `main` with:

```
bundle exec rspec --order defined spec/delayed/priority_spec.rb:158 spec/delayed/active_job_adapter_spec.rb:149
```

## Testing

- `spec/delayed/priority_spec.rb` extended: real-method introspection, method cleanup on `names=` reassignment, and collision safety.
- Full suite run locally on sqlite across multiple seeds; only failures are pre-existing on `main` in my local environment (Rails 8.0.2 snapshot/error-class drift, unrelated to this change).