### PR TITLE
Monitor by tag_columns (defaults with no tag_columns)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    delayed (4.0.1)
+    delayed (4.1.0)
       activerecord (>= 6.0)
       benchmark
       concurrent-ruby

--- a/README.md
+++ b/README.md
@@ -450,10 +450,15 @@ Delayed::Monitor.tag_columns = %i(name owner)
 
 A few behavioral notes:
 
-- Each tag column is added to the monitor's `GROUP BY`, and the generated indexes (e.g.
-  `idx_delayed_jobs_live`) cover only `priority` and `queue`. Grouping by anything else can push
-  these queries off their index and into significantly more expensive scans, so evaluate any tag
-  column by checking the query plans against a production-sized jobs table.
+- Each tag column is added to the monitor's `GROUP BY`, and no generated index contains a tag
+  column: `idx_delayed_jobs_live` covers `(priority, run_at, locked_at, queue, attempts)` and
+  `idx_delayed_jobs_failed` covers `(priority, queue)`. Grouping by a column outside these indexes
+  costs the monitor its covering-index reads and adds a sort. On PostgreSQL, the index-only scans
+  behind `delayed.job.count` become plain index scans — a heap fetch per matching row. On MySQL,
+  the failed-jobs query drops from a covering index range scan to a full table scan. These are
+  queries the monitor re-runs every `sleep_delay` (60 seconds by default), and plan choices shift
+  with table size, so check the plans against a production-sized jobs table before enabling a tag
+  column.
 - Rows whose value was never populated for a tagged column are reported under the value `'unset'`
   (e.g. jobs enqueued before the `name` column existed, mid-upgrade).
 - Configured columns must exist on the jobs table: assigning a missing column to `tag_columns`

--- a/README.md
+++ b/README.md
@@ -434,8 +434,26 @@ An additional _experimental_ metric is available, intended for use with applicat
 
 - **delayed.job.alert_age_percent** - the _percent_ to which the oldest job has reached the "age alert" threshold. (See the [Alerting Threshholds](#priority-based-alerting-threshholds) section above.)
 
-All of these events may be subscribed to via a single regular expression (again, in your application
-config or in an initializer):
+If your jobs table has a `name` column (see [Database Setup](#database-setup)), one additional
+event will be emitted, grouped by priority name, queue name, **and job name**:
+
+- **delayed.job.max_age_by_name** - the age of the oldest run_at value, per job name (excludes failed jobs)
+
+This answers "_which_ job is stuck?" when `delayed.job.max_age` alerts. A few behavioral notes:
+
+- Unlike the other metrics, it is not zero-filled: job names cannot be enumerated in advance, so a
+  (priority, queue, name) series is only emitted while matching jobs are present in the queue.
+- Jobs enqueued before the `name` column existed (i.e. mid-upgrade) are reported under the name
+  `"unknown"`.
+- Because this metric's cardinality scales with the number of distinct job names, it can be
+  disabled if that's a concern for your metrics provider:
+
+```ruby
+Delayed::Monitor.emit_max_age_by_name = false
+```
+
+All of these events (including `max_age_by_name`) may be subscribed to via a single regular
+expression (again, in your application config or in an initializer):
 
 ```ruby
 ActiveSupport::Notifications.subscribe(/delayed\.job\..*_(count|age|percent)/) do |*args|

--- a/README.md
+++ b/README.md
@@ -417,10 +417,10 @@ QUEUES=mailers,tasks rake delayed:monitor
 ```
 
 The following events will be emitted, grouped by priority name (e.g. "interactive"), queue name,
-and the values of any configured `tag_columns`. By default, job `name` is included. The
-metric's "`:value`" will be available in the event's payload.  **This means that there will be one
-value _per_ unique combination of queue, priority, and tag column values**, and totals must be
-computed via downstream aggregation (e.g. as a StatsD "gauge" metric, summed or maxed by tag).
+and the values of any columns configured via `tag_columns` (none, by default). The metric's
+"`:value`" will be available in the event's payload.  **This means that there will be one value
+_per_ unique combination of queue, priority, and tag column values**, and totals must be computed
+via downstream aggregation (e.g. as a StatsD "gauge" metric, summed or maxed by tag).
 
 - **delayed.job.count** - the total number of jobs
 - **delayed.job.future_count** - jobs where run_at is in the future
@@ -436,15 +436,13 @@ An additional _experimental_ metric is available, intended for use with applicat
 
 - **delayed.job.alert_age_percent** - the _percent_ to which the oldest job has reached the "age alert" threshold. (See the [Alerting Threshholds](#priority-based-alerting-threshholds) section above.)
 
-By default, these events are also tagged with the job's `name` (when the jobs table has a `name`
-column — see [Database Setup](#database-setup)) so that downstream aggregation can answer
-"_which_ job is stuck?" when `delayed.job.max_age` alerts (e.g. `max by {queue, priority, name}`
-in Datadog).
+#### Tagging metrics with additional columns
 
-The set of tagged columns is driven by `Delayed::Monitor.tag_columns`, which defaults to
-`%i(name)` when the jobs table has a `name` column (and to `[]` otherwise). You can include
-columns your application adds to the jobs table (populated at enqueue time). For example, if your
-jobs table has an `owner` column you wish to also monitor:
+These events can also be tagged with the values of other jobs-table columns, so that downstream
+aggregation can answer "_which_ job is stuck?" when `delayed.job.max_age` alerts (e.g.
+`max by {queue, priority, name}` in Datadog). This is opt-in via `Delayed::Monitor.tag_columns`,
+which defaults to `[]`. To tag by the job's `name` (see [Database Setup](#database-setup)) plus an
+`owner` column your application has added to the jobs table and populates at enqueue time:
 
 ```ruby
 Delayed::Monitor.tag_columns = %i(name owner)
@@ -452,6 +450,10 @@ Delayed::Monitor.tag_columns = %i(name owner)
 
 A few behavioral notes:
 
+- Each tag column is added to the monitor's `GROUP BY`, and the generated indexes (e.g.
+  `idx_delayed_jobs_live`) cover only `priority` and `queue`. Grouping by anything else can push
+  these queries off their index and into significantly more expensive scans, so evaluate any tag
+  column by checking the query plans against a production-sized jobs table.
 - Rows whose value was never populated for a tagged column are reported under the value `'unset'`
   (e.g. jobs enqueued before the `name` column existed, mid-upgrade).
 - Configured columns must exist on the jobs table: assigning a missing column to `tag_columns`
@@ -461,8 +463,8 @@ A few behavioral notes:
 - Tag values cannot be enumerated in advance, so a tagged series is only emitted while matching
   jobs are present. Separately, an untagged zero value is always emitted for every
   (priority, queue) combination, so that each metric maintains a baseline series even when no
-  matching jobs are enqueued. For example, `delayed.job.count` with a single enqueued job would
-  emit the following series:
+  matching jobs are enqueued. For example, with `tag_columns = %i(name)` and a single enqueued
+  job, `delayed.job.count` would emit the following series:
 
   ```ruby
   { priority: 'interactive', queue: 'default', name: 'SimpleJob', value: 1 }
@@ -473,13 +475,12 @@ A few behavioral notes:
   ```
 - Each column multiplies a metric's series cardinality by its number of distinct values (though in
   practice a job's `name` tends to determine its `priority` and any ownership tags, making the
-  number of distinct job names the effective upper bound). If cardinality is a concern for your
-  metrics provider, tagging can be disabled entirely with `Delayed::Monitor.tag_columns = []`.
+  number of distinct job names the effective upper bound).
 
-#### Rolling out a new tag column
+#### Rolling out a tag column
 
-Because assignment fails loudly on a missing column, a new tag column should be rolled out in
-three separate deploys, each fully released before the next begins:
+Because assignment fails loudly on a missing column, a tag column should be rolled out in three
+separate deploys, each fully released before the next begins:
 
 1. Migrate the column onto the jobs table (nullable — no backfill required).
 2. Deploy the code that populates the column at enqueue time.
@@ -488,11 +489,6 @@ three separate deploys, each fully released before the next begins:
 Adding the column to `tag_columns` before the migration has run everywhere would raise at boot in
 every process that loads the initializer. Jobs enqueued before step 2 will report under the
 `'unset'` tag value until they are worked off (or backfilled).
-
-The default `name` tag needs no such rollout: it applies only when the jobs table already has a
-`name` column, so a monitor running against an older schema simply emits untagged metrics until
-the generated migrations (see [Database Setup](#database-setup)) have run and the monitor process
-has restarted (the default is resolved once per process).
 
 All of these events may be subscribed to via a single regular expression (again, in your
 application config or in an initializer):

--- a/README.md
+++ b/README.md
@@ -445,14 +445,47 @@ This answers "_which_ job is stuck?" when `delayed.job.max_age` alerts. A few be
   (priority, queue, name) series is only emitted while matching jobs are present in the queue.
 - Jobs enqueued before the `name` column existed (i.e. mid-upgrade) are reported under the name
   `"unknown"`.
-- Because this metric's cardinality scales with the number of distinct job names, it can be
-  disabled if that's a concern for your metrics provider:
+
+These by-attribute pairings are driven by `Delayed::Monitor.metrics_by_attribute`, which defaults
+to `{ max_age: %i(name) }`. Any metric can be paired with any groupable column — including columns
+your application adds to the jobs table (populated at enqueue time) — and each pairing emits its
+own **delayed.job.&lt;metric&gt;_by_&lt;column&gt;** event, grouped by priority name, queue name,
+and that column's value (`'unknown'` when NULL). For example, with a per-record `owner` column:
 
 ```ruby
-Delayed::Monitor.emit_max_age_by_name = false
+Delayed::Monitor.metrics_by_attribute = {
+  max_age: %i(name owner),
+  failed_count: %i(owner),
+}
 ```
 
-All of these events (including `max_age_by_name`) may be subscribed to via a single regular
+The above would result in the following monitors:
+
+- 'delayed.job.max_age_by_name'
+- 'delayed.job.max_age_by_owner'
+- 'delayed.job.failed_count_by_owner'
+
+Configured columns that do not (yet) exist on the table are skipped. For example:
+
+```ruby
+Delayed::Monitor.metrics_by_attribute = {
+  max_age: %i(owner non_existent_attribute),
+  failed_count: %i(owner),
+}
+```
+
+The above would result in the following monitors based on attribute column availability:
+
+- 'delayed.job.max_age_by_owner'
+- 'delayed.job.failed_count_by_owner'
+
+Metric names, on the other hand, are validated when the config is assigned — pairing a metric that
+does not exist (e.g. `min_age`) raises an `ArgumentError` at boot, rather than failing later in the
+monitor process.
+
+Each pairing's cardinality scales with the number of distinct values in the column, so if series cardinality is a concern for your metrics provider, by-attribute metrics can be disabled entirely by setting the config to `{}`.
+
+All of these events (including the `*_by_*` pairings) may be subscribed to via a single regular
 expression (again, in your application config or in an initializer):
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -435,10 +435,10 @@ via downstream aggregation (e.g. as a StatsD "gauge" metric, summed or maxed by 
 An additional _experimental_ metric is available, intended for use with application autoscaling:
 
 - **delayed.job.alert_age_percent** - the _percent_ to which the oldest job has reached the "age alert"
-  threshold. (See the [Alerting Threshholds](#priority-based-alerting-threshholds) section above.)
+threshold. (See the [Alerting Threshholds](#priority-based-alerting-threshholds) section above.)
 
-All of these events may be subscribed to via a single regular expression (again, in your
-application config or in an initializer):
+All of these events may be subscribed to via a single regular expression (again, in your application
+config or in an initializer):
 
 ```ruby
 ActiveSupport::Notifications.subscribe(/delayed\.job\..*_(count|age|percent)/) do |*args|

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ QUEUES=mailers,tasks rake delayed:monitor
 ```
 
 The following events will be emitted, grouped by priority name (e.g. "interactive"), queue name,
-and the values of any columns configured via `tag_columns` (none, by default). The metric's
+and the values of any columns configured via [tag_columns](#tagging-metrics-with-additional-columns) (none, by default). The metric's
 "`:value`" will be available in the event's payload.  **This means that there will be one value
 _per_ unique combination of queue, priority, and tag column values**, and totals must be computed
 via downstream aggregation (e.g. as a StatsD "gauge" metric, summed or maxed by tag).
@@ -434,66 +434,8 @@ via downstream aggregation (e.g. as a StatsD "gauge" metric, summed or maxed by 
 
 An additional _experimental_ metric is available, intended for use with application autoscaling:
 
-- **delayed.job.alert_age_percent** - the _percent_ to which the oldest job has reached the "age alert" threshold. (See the [Alerting Threshholds](#priority-based-alerting-threshholds) section above.)
-
-#### Tagging metrics with additional columns
-
-These events can also be tagged with the values of other jobs-table columns, so that downstream
-aggregation can answer "_which_ job is stuck?" when `delayed.job.max_age` alerts (e.g.
-`max by {queue, priority, name}` in Datadog). This is opt-in via `Delayed::Monitor.tag_columns`,
-which defaults to `[]`. To tag by the job's `name` (see [Database Setup](#database-setup)) plus an
-`owner` column your application has added to the jobs table and populates at enqueue time:
-
-```ruby
-Delayed::Monitor.tag_columns = %i(name owner)
-```
-
-A few behavioral notes:
-
-- Each tag column is added to the monitor's `GROUP BY`, and no generated index contains a tag
-  column: `idx_delayed_jobs_live` covers `(priority, run_at, locked_at, queue, attempts)` and
-  `idx_delayed_jobs_failed` covers `(priority, queue)`. Grouping by a column outside these indexes
-  costs the monitor its covering-index reads and adds a sort. On PostgreSQL, the index-only scans
-  behind `delayed.job.count` become plain index scans — a heap fetch per matching row. On MySQL,
-  the failed-jobs query drops from a covering index range scan to a full table scan. These are
-  queries the monitor re-runs every `sleep_delay` (60 seconds by default), and plan choices shift
-  with table size, so check the plans against a production-sized jobs table before enabling a tag
-  column.
-- Rows whose value was never populated for a tagged column are reported under the value `'unset'`
-  (e.g. jobs enqueued before the `name` column existed, mid-upgrade).
-- Configured columns must exist on the jobs table: assigning a missing column to `tag_columns`
-  raises an `ArgumentError` immediately, rather than the column being silently skipped. Because
-  the assignment validates against the schema, setting `tag_columns` in an initializer requires a
-  database connection at boot, in every process that loads it. See the rollout steps below.
-- Tag values cannot be enumerated in advance, so a tagged series is only emitted while matching
-  jobs are present. Separately, an untagged zero value is always emitted for every
-  (priority, queue) combination, so that each metric maintains a baseline series even when no
-  matching jobs are enqueued. For example, with `tag_columns = %i(name)` and a single enqueued
-  job, `delayed.job.count` would emit the following series:
-
-  ```ruby
-  { priority: 'interactive', queue: 'default', name: 'SimpleJob', value: 1 }
-  { priority: 'interactive', queue: 'default', value: 0 }
-  { priority: 'user_visible', queue: 'default', value: 0 }
-  { priority: 'eventual', queue: 'default', value: 0 }
-  { priority: 'reporting', queue: 'default', value: 0 }
-  ```
-- Each column multiplies a metric's series cardinality by its number of distinct values (though in
-  practice a job's `name` tends to determine its `priority` and any ownership tags, making the
-  number of distinct job names the effective upper bound).
-
-#### Rolling out a tag column
-
-Because assignment fails loudly on a missing column, a tag column should be rolled out in three
-separate deploys, each fully released before the next begins:
-
-1. Migrate the column onto the jobs table (nullable — no backfill required).
-2. Deploy the code that populates the column at enqueue time.
-3. Add the column to `Delayed::Monitor.tag_columns` in an initializer, and deploy.
-
-Adding the column to `tag_columns` before the migration has run everywhere would raise at boot in
-every process that loads the initializer. Jobs enqueued before step 2 will report under the
-`'unset'` tag value until they are worked off (or backfilled).
+- **delayed.job.alert_age_percent** - the _percent_ to which the oldest job has reached the "age alert"
+  threshold. (See the [Alerting Threshholds](#priority-based-alerting-threshholds) section above.)
 
 All of these events may be subscribed to via a single regular expression (again, in your
 application config or in an initializer):
@@ -518,6 +460,40 @@ ActiveSupport::Notifications.subscribe('delayed.monitor.run') do |*args|
   StatsD.distribution(...)
 end
 ```
+
+#### Tagging metrics with additional columns
+
+By default, the monitor only groups events by `priority` and `queue`. To add additional columns
+to the query's `GROUP BY` clause, declare them in an initializer config:
+
+```ruby
+Delayed::Monitor.tag_columns = %i(name owner)
+```
+
+Tagged series are only emitted while matching jobs exist, and an untagged zero is always emitted
+per (priority, queue) as a baseline. With `Delayed::Monitor.tag_columns = %i(name)` and one
+enqueued job, `delayed.job.count` emits:
+
+```ruby
+{ priority: 'interactive', queue: 'default', name: 'SimpleJob', value: 1 }
+{ priority: 'interactive', queue: 'default', value: 0 }
+{ priority: 'user_visible', queue: 'default', value: 0 }
+{ priority: 'eventual', queue: 'default', value: 0 }
+{ priority: 'reporting', queue: 'default', value: 0 }
+```
+
+Tag columns must already exist on the jobs table — the monitor validates this at startup and
+raises an `ArgumentError` if any are missing, so migrate a new column before adding it here.
+
+`NULL` values are emitted as `nil` tags. Your notification subscriber can decide how to represent
+these. Expect `nil`s for jobs enqueued before a newly added column was populated.
+
+**Avoid** choosing high-cardinality columns like `id` as this will result in very poor query
+performance (and may essentially turn every row into its own metric result!). Prefer low-cardinality
+columns like `name` (the name of the job class) that are worth the query performance trade-off.
+
+**You are strongly encouraged to add new indexes** incorporating those columns. When adding `tag_columns`,
+`idx_delayed_jobs_live` and `idx_delayed_jobs_failed` will no longer fully cover the monitor's queries.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -416,14 +416,16 @@ QUEUE=tracking rake delayed:monitor
 QUEUES=mailers,tasks rake delayed:monitor
 ```
 
-The following events will be emitted, grouped by priority name (e.g. "interactive") and queue name,
-and the metric's "`:value`" will be available in the event's payload.  **This means that there will
-be one value _per_ unique combination of queue & priority**, and totals must be computed via
-downstream aggregation (e.g. as a StatsD "gauge" metric).
+The following events will be emitted, grouped by priority name (e.g. "interactive"), queue name,
+and the values of any configured `tag_columns`. By default, job `name` is included. The
+metric's "`:value`" will be available in the event's payload.  **This means that there will be one
+value _per_ unique combination of queue, priority, and tag column values**, and totals must be
+computed via downstream aggregation (e.g. as a StatsD "gauge" metric, summed or maxed by tag).
 
 - **delayed.job.count** - the total number of jobs
 - **delayed.job.future_count** - jobs where run_at is in the future
 - **delayed.job.working_count** - jobs that are currently being worked off (excludes failed jobs)
+- **delayed.job.locked_count** - jobs that are currently locked by a worker (equivalent to working_count)
 - **delayed.job.workable_count** - jobs that are waiting to be worked off
 - **delayed.job.erroring_count** - jobs where attempts > 0
 - **delayed.job.failed_count** - jobs where failed_at is not nil
@@ -434,59 +436,66 @@ An additional _experimental_ metric is available, intended for use with applicat
 
 - **delayed.job.alert_age_percent** - the _percent_ to which the oldest job has reached the "age alert" threshold. (See the [Alerting Threshholds](#priority-based-alerting-threshholds) section above.)
 
-If your jobs table has a `name` column (see [Database Setup](#database-setup)), one additional
-event will be emitted, grouped by priority name, queue name, **and job name**:
+By default, these events are also tagged with the job's `name` (when the jobs table has a `name`
+column — see [Database Setup](#database-setup)) so that downstream aggregation can answer
+"_which_ job is stuck?" when `delayed.job.max_age` alerts (e.g. `max by {queue, priority, name}`
+in Datadog).
 
-- **delayed.job.max_age_by_name** - the age of the oldest run_at value, per job name (excludes failed jobs)
-
-This answers "_which_ job is stuck?" when `delayed.job.max_age` alerts. A few behavioral notes:
-
-- Unlike the other metrics, it is not zero-filled: job names cannot be enumerated in advance, so a
-  (priority, queue, name) series is only emitted while matching jobs are present in the queue.
-- Jobs enqueued before the `name` column existed (i.e. mid-upgrade) are reported under the name
-  `"unknown"`.
-
-These by-attribute pairings are driven by `Delayed::Monitor.metrics_by_attribute`, which defaults
-to `{ max_age: %i(name) }`. Any metric can be paired with any groupable column — including columns
-your application adds to the jobs table (populated at enqueue time) — and each pairing emits its
-own **delayed.job.&lt;metric&gt;_by_&lt;column&gt;** event, grouped by priority name, queue name,
-and that column's value (`'unknown'` when NULL). For example, with a per-record `owner` column:
+The set of tagged columns is driven by `Delayed::Monitor.tag_columns`, which defaults to
+`%i(name)` when the jobs table has a `name` column (and to `[]` otherwise). You can include
+columns your application adds to the jobs table (populated at enqueue time). For example, if your
+jobs table has an `owner` column you wish to also monitor:
 
 ```ruby
-Delayed::Monitor.metrics_by_attribute = {
-  max_age: %i(name owner),
-  failed_count: %i(owner),
-}
+Delayed::Monitor.tag_columns = %i(name owner)
 ```
 
-The above would result in the following monitors:
+A few behavioral notes:
 
-- 'delayed.job.max_age_by_name'
-- 'delayed.job.max_age_by_owner'
-- 'delayed.job.failed_count_by_owner'
+- Rows whose value was never populated for a tagged column are reported under the value `'unset'`
+  (e.g. jobs enqueued before the `name` column existed, mid-upgrade).
+- Configured columns must exist on the jobs table: assigning a missing column to `tag_columns`
+  raises an `ArgumentError` immediately, rather than the column being silently skipped. Because
+  the assignment validates against the schema, setting `tag_columns` in an initializer requires a
+  database connection at boot, in every process that loads it. See the rollout steps below.
+- Tag values cannot be enumerated in advance, so a tagged series is only emitted while matching
+  jobs are present. Separately, an untagged zero value is always emitted for every
+  (priority, queue) combination, so that each metric maintains a baseline series even when no
+  matching jobs are enqueued. For example, `delayed.job.count` with a single enqueued job would
+  emit the following series:
 
-Configured columns that do not (yet) exist on the table are skipped. For example:
+  ```ruby
+  { priority: 'interactive', queue: 'default', name: 'SimpleJob', value: 1 }
+  { priority: 'interactive', queue: 'default', value: 0 }
+  { priority: 'user_visible', queue: 'default', value: 0 }
+  { priority: 'eventual', queue: 'default', value: 0 }
+  { priority: 'reporting', queue: 'default', value: 0 }
+  ```
+- Each column multiplies a metric's series cardinality by its number of distinct values (though in
+  practice a job's `name` tends to determine its `priority` and any ownership tags, making the
+  number of distinct job names the effective upper bound). If cardinality is a concern for your
+  metrics provider, tagging can be disabled entirely with `Delayed::Monitor.tag_columns = []`.
 
-```ruby
-Delayed::Monitor.metrics_by_attribute = {
-  max_age: %i(owner non_existent_attribute),
-  failed_count: %i(owner),
-}
-```
+#### Rolling out a new tag column
 
-The above would result in the following monitors based on attribute column availability:
+Because assignment fails loudly on a missing column, a new tag column should be rolled out in
+three separate deploys, each fully released before the next begins:
 
-- 'delayed.job.max_age_by_owner'
-- 'delayed.job.failed_count_by_owner'
+1. Migrate the column onto the jobs table (nullable — no backfill required).
+2. Deploy the code that populates the column at enqueue time.
+3. Add the column to `Delayed::Monitor.tag_columns` in an initializer, and deploy.
 
-Metric names, on the other hand, are validated when the config is assigned — pairing a metric that
-does not exist (e.g. `min_age`) raises an `ArgumentError` at boot, rather than failing later in the
-monitor process.
+Adding the column to `tag_columns` before the migration has run everywhere would raise at boot in
+every process that loads the initializer. Jobs enqueued before step 2 will report under the
+`'unset'` tag value until they are worked off (or backfilled).
 
-Each pairing's cardinality scales with the number of distinct values in the column, so if series cardinality is a concern for your metrics provider, by-attribute metrics can be disabled entirely by setting the config to `{}`.
+The default `name` tag needs no such rollout: it applies only when the jobs table already has a
+`name` column, so a monitor running against an older schema simply emits untagged metrics until
+the generated migrations (see [Database Setup](#database-setup)) have run and the monitor process
+has restarted (the default is resolved once per process).
 
-All of these events (including the `*_by_*` pairings) may be subscribed to via a single regular
-expression (again, in your application config or in an initializer):
+All of these events may be subscribed to via a single regular expression (again, in your
+application config or in an initializer):
 
 ```ruby
 ActiveSupport::Notifications.subscribe(/delayed\.job\..*_(count|age|percent)/) do |*args|
@@ -499,7 +508,7 @@ ActiveSupport::Notifications.subscribe(/delayed\.job\..*_(count|age|percent)/) d
 end
 ```
 
-Additionally, the monitor process with emit a **delayed.monitor.run** event with a duration
+Additionally, the monitor process will emit a **delayed.monitor.run** event with a duration
 attached, so that you can monitor the time it takes to emit these aggregate metrics.
 
 ```ruby

--- a/lib/delayed/monitor.rb
+++ b/lib/delayed/monitor.rb
@@ -17,18 +17,17 @@ module Delayed
 
     cattr_accessor :sleep_delay, instance_writer: false, default: 60
 
-    def self.metrics_by_attribute
-      @metrics_by_attribute ||= { max_age: %i(name) }.freeze
+    def self.tag_columns
+      @tag_columns ||= (Job.column_names.include?('name') ? %i(name) : []).freeze
     end
 
-    def self.metrics_by_attribute=(value)
-      unknown_metrics = value.keys.map(&:to_s) - METRICS
-      if unknown_metrics.any?
-        raise ArgumentError, "Unknown metrics in metrics_by_attribute: #{unknown_metrics.join(', ')}. " \
-                             "Valid metrics: #{METRICS.join(', ')}"
+    def self.tag_columns=(columns)
+      if columns.any? { |column| Job.column_names.exclude?(column.to_s) }
+        raise ArgumentError, "Delayed::Monitor.tag_columns includes columns missing from #{Job.table_name}. " \
+                             "Available columns: #{Job.column_names.join(', ')}"
       end
 
-      @metrics_by_attribute = value.freeze
+      @tag_columns = columns.map(&:to_sym).freeze
     end
 
     def initialize
@@ -41,13 +40,12 @@ module Delayed
       @memo = {}
       ActiveSupport::Notifications.instrument('delayed.monitor.run', default_tags) do
         METRICS.each { |metric| emit_metric!(metric) }
-        assignable_metrics_by_attribute.each { |(metric, attribute)| emit_metric_by_attribute!(metric, attribute) }
       end
       interruptable_sleep(sleep_delay)
     end
 
-    def query_for(metric, *args)
-      send(:"#{metric}_grouped", *args)
+    def query_for(metric)
+      send(:"#{metric}_grouped")
     end
 
     def self.sql_now_in_utc
@@ -82,26 +80,14 @@ module Delayed
     attr_reader :jobs
 
     def emit_metric!(metric)
-      query_for(metric).reverse_merge(default_results).each do |(priority, queue), value|
+      query_for(metric)
+        .merge!(default_results) { |_key, existing, _default| existing }
+        .each do |(priority, queue, *column_values), value|
+        tags = column_values.zip(self.class.tag_columns).to_h { |val, column| [column, val.nil? ? 'unset' : val] }
         ActiveSupport::Notifications.instrument(
           "delayed.job.#{metric}",
-          default_tags.merge(priority: Priority.new(priority).to_s, queue: queue, value: value),
+          default_tags.merge(priority: Priority.new(priority).to_s, queue: queue, **tags, value: value),
         )
-      end
-    end
-
-    def emit_metric_by_attribute!(metric, attribute)
-      query_for(metric, attribute).each do |(priority, queue, label), value|
-        tags = { priority: Priority.new(priority).to_s, queue: queue, attribute => label || 'unknown', value: value }
-        ActiveSupport::Notifications.instrument("delayed.job.#{metric}_by_#{attribute}", default_tags.merge(tags))
-      end
-    end
-
-    def assignable_metrics_by_attribute
-      self.class.metrics_by_attribute.flat_map do |metric, attributes|
-        Array(attributes)
-          .select { |attribute| Job.column_names.include?(attribute.to_s) }
-          .map { |attribute| [metric.to_s, attribute.to_sym] }
       end
     end
 
@@ -154,48 +140,48 @@ module Delayed
       "#{aggregate_function.to_s.upcase}(#{aggregate_expression}) AS #{column_name}"
     end
 
-    def count_grouped(attribute = nil)
-      failed_count_grouped(attribute).merge(live_count_grouped(attribute)) { |_, l, f| l + f }
+    def count_grouped
+      failed_count_grouped.merge(live_count_grouped) { |_, l, f| l + f }
     end
 
-    def live_count_grouped(attribute = nil)
-      live_counts(attribute).transform_values(&:count)
+    def live_count_grouped
+      live_counts.transform_values(&:count)
     end
 
-    def future_count_grouped(attribute = nil)
-      live_counts(attribute).transform_values(&:future_count)
+    def future_count_grouped
+      live_counts.transform_values(&:future_count)
     end
 
-    def erroring_count_grouped(attribute = nil)
-      live_counts(attribute).transform_values(&:erroring_count)
+    def erroring_count_grouped
+      live_counts.transform_values(&:erroring_count)
     end
 
-    def locked_count_grouped(attribute = nil)
-      pending_counts(attribute).transform_values(&:claimed_count)
+    def locked_count_grouped
+      pending_counts.transform_values(&:claimed_count)
     end
 
-    def failed_count_grouped(attribute = nil)
-      failed_counts(attribute).transform_values(&:count)
+    def failed_count_grouped
+      failed_counts.transform_values(&:count)
     end
 
-    def max_lock_age_grouped(attribute = nil)
-      pending_counts(attribute).transform_values { |j| time_ago(db_now(j), j.locked_at) }
+    def max_lock_age_grouped
+      pending_counts.transform_values { |j| time_ago(db_now(j), j.locked_at) }
     end
 
-    def max_age_grouped(attribute = nil)
-      pending_counts(attribute).transform_values { |j| time_ago(db_now(j), j.run_at) }
+    def max_age_grouped
+      pending_counts.transform_values { |j| time_ago(db_now(j), j.run_at) }
     end
 
-    def alert_age_percent_grouped(attribute = nil)
-      pending_counts(attribute).each_with_object({}) do |(key, j), metrics|
+    def alert_age_percent_grouped
+      pending_counts.each_with_object({}) do |(key, j), metrics|
         max_age = time_ago(db_now(j), j.run_at)
         alert_age = Priority.new(key.first).alert_age
         metrics[key] = [max_age / alert_age * 100, 100].min if alert_age
       end
     end
 
-    def workable_count_grouped(attribute = nil)
-      pending_counts(attribute).transform_values(&:claimable_count)
+    def workable_count_grouped
+      pending_counts.transform_values(&:claimable_count)
     end
 
     alias working_count_grouped locked_count_grouped
@@ -208,21 +194,21 @@ module Delayed
       pending_counts.transform_values(&:run_at).compact
     end
 
-    def live_counts(attribute = nil)
-      @memo[[:live_counts, attribute]] ||= grouped_query(
+    def live_counts
+      @memo[:live_counts] ||= grouped_query(
         jobs.live,
-        extra_group_columns: [attribute].compact,
+        extra_group_columns: self.class.tag_columns,
         count: [:count, '*'],
         future_count: [:sum, case_when(Job.future_clause.to_sql)],
         erroring_count: [:sum, case_when(Job.erroring_clause.to_sql)],
       )
     end
 
-    def pending_counts(attribute = nil)
-      @memo[[:pending_counts, attribute]] ||= grouped_query(
+    def pending_counts
+      @memo[:pending_counts] ||= grouped_query(
         jobs.pending,
         include_db_time: true,
-        extra_group_columns: [attribute].compact,
+        extra_group_columns: self.class.tag_columns,
         claimed_count: [:sum, case_when(Job.claimed_clause.to_sql)],
         claimable_count: [:sum, case_when(Job.claimable_clause.to_sql)],
         locked_at: [:min, case_when(Job.claimed_clause.to_sql, 'locked_at')],
@@ -230,9 +216,9 @@ module Delayed
       )
     end
 
-    def failed_counts(attribute = nil)
-      @memo[[:failed_counts, attribute]] ||=
-        grouped_query(jobs.failed, extra_group_columns: [attribute].compact, count: [:count, '*'])
+    def failed_counts
+      @memo[:failed_counts] ||=
+        grouped_query(jobs.failed, extra_group_columns: self.class.tag_columns, count: [:count, '*'])
     end
 
     def db_now(record)

--- a/lib/delayed/monitor.rb
+++ b/lib/delayed/monitor.rb
@@ -16,6 +16,7 @@ module Delayed
     ).freeze
 
     cattr_accessor :sleep_delay, instance_writer: false, default: 60
+    cattr_accessor :emit_max_age_by_name, instance_writer: false, default: true
 
     def initialize
       @jobs = Job.group(:priority, :queue)
@@ -27,6 +28,7 @@ module Delayed
       @memo = {}
       ActiveSupport::Notifications.instrument('delayed.monitor.run', default_tags) do
         METRICS.each { |metric| emit_metric!(metric) }
+        emit_metric_by_name!('max_age') if emit_max_age_by_name && Job.name_assignable?
       end
       interruptable_sleep(sleep_delay)
     end
@@ -75,6 +77,15 @@ module Delayed
       end
     end
 
+    def emit_metric_by_name!(metric)
+      query_for("#{metric}_by_name").each do |(priority, queue, name), value|
+        ActiveSupport::Notifications.instrument(
+          "delayed.job.#{metric}_by_name",
+          default_tags.merge(priority: Priority.new(priority).to_s, queue: queue, name: name || 'unknown', value: value),
+        )
+      end
+    end
+
     def default_results
       @default_results ||= Priority.names.values.flat_map { |priority|
         (Worker.queues.presence || [Worker.default_queue_name]).map do |queue|
@@ -96,22 +107,28 @@ module Delayed
     end
 
     # This method generates a query that scans the specified scope, groups by
-    # priority and queue, and calculates the specified aggregates. An outer
-    # query is executed for priority bucketing and appending db_now_utc (to
-    # avoid running these computations for each tuple in the inner query).
-    def grouped_query(scope, include_db_time: false, **kwargs)
+    # priority and queue (plus any extra_group_columns), and calculates the
+    # specified aggregates. An outer query is executed for priority bucketing
+    # and appending db_now_utc (to avoid running these computations for each
+    # tuple in the inner query).
+    def grouped_query(scope, include_db_time: false, extra_group_columns: [], **kwargs)
       inner_selects = kwargs.map { |key, (agg, expr)| as_expression(agg, expr, key) }
       outer_selects = kwargs.map { |key, (agg, _)| as_expression(agg == :count ? :sum : agg, key, key) }
       outer_selects << "#{self.class.sql_now_in_utc} AS db_now_utc" if include_db_time
 
       Delayed::Job
-        .from(scope.select(:priority, :queue, *inner_selects).group(:priority, :queue))
-        .group(priority_case_statement, :queue).select(
+        .from(scope.select(:priority, :queue, *extra_group_columns, *inner_selects).group(:priority, :queue, *extra_group_columns))
+        .group(priority_case_statement, :queue, *extra_group_columns).select(
           *outer_selects,
           "#{priority_case_statement} AS priority",
           'queue AS queue',
-        ).group_by { |j| [j.priority.to_i, j.queue] }
+          *extra_group_columns.map { |column| "#{column} AS #{column}" },
+        ).group_by { |j| result_key(j, extra_group_columns) }
         .transform_values(&:first)
+    end
+
+    def result_key(record, extra_group_columns)
+      [record.priority.to_i, record.queue, *extra_group_columns.map { |column| record[column] }]
     end
 
     def as_expression(aggregate_function, aggregate_expression, column_name)
@@ -148,6 +165,10 @@ module Delayed
 
     def max_age_grouped
       pending_counts.transform_values { |j| time_ago(db_now(j), j.run_at) }
+    end
+
+    def max_age_by_name_grouped
+      pending_run_ats_by_name.transform_values { |j| time_ago(db_now(j), j.run_at) }
     end
 
     def alert_age_percent_grouped
@@ -188,6 +209,15 @@ module Delayed
         claimed_count: [:sum, case_when(Job.claimed_clause.to_sql)],
         claimable_count: [:sum, case_when(Job.claimable_clause.to_sql)],
         locked_at: [:min, case_when(Job.claimed_clause.to_sql, 'locked_at')],
+        run_at: [:min, case_when(Job.claimable_clause.to_sql, 'run_at')],
+      )
+    end
+
+    def pending_run_ats_by_name
+      @memo[:pending_run_ats_by_name] ||= grouped_query(
+        jobs.pending,
+        include_db_time: true,
+        extra_group_columns: %i(name),
         run_at: [:min, case_when(Job.claimable_clause.to_sql, 'run_at')],
       )
     end

--- a/lib/delayed/monitor.rb
+++ b/lib/delayed/monitor.rb
@@ -16,7 +16,20 @@ module Delayed
     ).freeze
 
     cattr_accessor :sleep_delay, instance_writer: false, default: 60
-    cattr_accessor :emit_max_age_by_name, instance_writer: false, default: true
+
+    def self.metrics_by_attribute
+      @metrics_by_attribute ||= { max_age: %i(name) }.freeze
+    end
+
+    def self.metrics_by_attribute=(value)
+      unknown_metrics = value.keys.map(&:to_s) - METRICS
+      if unknown_metrics.any?
+        raise ArgumentError, "Unknown metrics in metrics_by_attribute: #{unknown_metrics.join(', ')}. " \
+                             "Valid metrics: #{METRICS.join(', ')}"
+      end
+
+      @metrics_by_attribute = value.freeze
+    end
 
     def initialize
       @jobs = Job.group(:priority, :queue)
@@ -28,13 +41,13 @@ module Delayed
       @memo = {}
       ActiveSupport::Notifications.instrument('delayed.monitor.run', default_tags) do
         METRICS.each { |metric| emit_metric!(metric) }
-        emit_metric_by_name!('max_age') if emit_max_age_by_name && Job.name_assignable?
+        assignable_metrics_by_attribute.each { |(metric, attribute)| emit_metric_by_attribute!(metric, attribute) }
       end
       interruptable_sleep(sleep_delay)
     end
 
-    def query_for(metric)
-      send(:"#{metric}_grouped")
+    def query_for(metric, *args)
+      send(:"#{metric}_grouped", *args)
     end
 
     def self.sql_now_in_utc
@@ -77,12 +90,18 @@ module Delayed
       end
     end
 
-    def emit_metric_by_name!(metric)
-      query_for("#{metric}_by_name").each do |(priority, queue, name), value|
-        ActiveSupport::Notifications.instrument(
-          "delayed.job.#{metric}_by_name",
-          default_tags.merge(priority: Priority.new(priority).to_s, queue: queue, name: name || 'unknown', value: value),
-        )
+    def emit_metric_by_attribute!(metric, attribute)
+      query_for(metric, attribute).each do |(priority, queue, label), value|
+        tags = { priority: Priority.new(priority).to_s, queue: queue, attribute => label || 'unknown', value: value }
+        ActiveSupport::Notifications.instrument("delayed.job.#{metric}_by_#{attribute}", default_tags.merge(tags))
+      end
+    end
+
+    def assignable_metrics_by_attribute
+      self.class.metrics_by_attribute.flat_map do |metric, attributes|
+        Array(attributes)
+          .select { |attribute| Job.column_names.include?(attribute.to_s) }
+          .map { |attribute| [metric.to_s, attribute.to_sym] }
       end
     end
 
@@ -135,52 +154,48 @@ module Delayed
       "#{aggregate_function.to_s.upcase}(#{aggregate_expression}) AS #{column_name}"
     end
 
-    def count_grouped
-      failed_count_grouped.merge(live_count_grouped) { |_, l, f| l + f }
+    def count_grouped(attribute = nil)
+      failed_count_grouped(attribute).merge(live_count_grouped(attribute)) { |_, l, f| l + f }
     end
 
-    def live_count_grouped
-      live_counts.transform_values(&:count)
+    def live_count_grouped(attribute = nil)
+      live_counts(attribute).transform_values(&:count)
     end
 
-    def future_count_grouped
-      live_counts.transform_values(&:future_count)
+    def future_count_grouped(attribute = nil)
+      live_counts(attribute).transform_values(&:future_count)
     end
 
-    def erroring_count_grouped
-      live_counts.transform_values(&:erroring_count)
+    def erroring_count_grouped(attribute = nil)
+      live_counts(attribute).transform_values(&:erroring_count)
     end
 
-    def locked_count_grouped
-      pending_counts.transform_values(&:claimed_count)
+    def locked_count_grouped(attribute = nil)
+      pending_counts(attribute).transform_values(&:claimed_count)
     end
 
-    def failed_count_grouped
-      failed_counts.transform_values(&:count)
+    def failed_count_grouped(attribute = nil)
+      failed_counts(attribute).transform_values(&:count)
     end
 
-    def max_lock_age_grouped
-      pending_counts.transform_values { |j| time_ago(db_now(j), j.locked_at) }
+    def max_lock_age_grouped(attribute = nil)
+      pending_counts(attribute).transform_values { |j| time_ago(db_now(j), j.locked_at) }
     end
 
-    def max_age_grouped
-      pending_counts.transform_values { |j| time_ago(db_now(j), j.run_at) }
+    def max_age_grouped(attribute = nil)
+      pending_counts(attribute).transform_values { |j| time_ago(db_now(j), j.run_at) }
     end
 
-    def max_age_by_name_grouped
-      pending_run_ats_by_name.transform_values { |j| time_ago(db_now(j), j.run_at) }
-    end
-
-    def alert_age_percent_grouped
-      pending_counts.each_with_object({}) do |((priority, queue), j), metrics|
+    def alert_age_percent_grouped(attribute = nil)
+      pending_counts(attribute).each_with_object({}) do |(key, j), metrics|
         max_age = time_ago(db_now(j), j.run_at)
-        alert_age = Priority.new(priority).alert_age
-        metrics[[priority, queue]] = [max_age / alert_age * 100, 100].min if alert_age
+        alert_age = Priority.new(key.first).alert_age
+        metrics[key] = [max_age / alert_age * 100, 100].min if alert_age
       end
     end
 
-    def workable_count_grouped
-      pending_counts.transform_values(&:claimable_count)
+    def workable_count_grouped(attribute = nil)
+      pending_counts(attribute).transform_values(&:claimable_count)
     end
 
     alias working_count_grouped locked_count_grouped
@@ -193,19 +208,21 @@ module Delayed
       pending_counts.transform_values(&:run_at).compact
     end
 
-    def live_counts
-      @memo[:live_counts] ||= grouped_query(
+    def live_counts(attribute = nil)
+      @memo[[:live_counts, attribute]] ||= grouped_query(
         jobs.live,
+        extra_group_columns: [attribute].compact,
         count: [:count, '*'],
         future_count: [:sum, case_when(Job.future_clause.to_sql)],
         erroring_count: [:sum, case_when(Job.erroring_clause.to_sql)],
       )
     end
 
-    def pending_counts
-      @memo[:pending_counts] ||= grouped_query(
+    def pending_counts(attribute = nil)
+      @memo[[:pending_counts, attribute]] ||= grouped_query(
         jobs.pending,
         include_db_time: true,
+        extra_group_columns: [attribute].compact,
         claimed_count: [:sum, case_when(Job.claimed_clause.to_sql)],
         claimable_count: [:sum, case_when(Job.claimable_clause.to_sql)],
         locked_at: [:min, case_when(Job.claimed_clause.to_sql, 'locked_at')],
@@ -213,17 +230,9 @@ module Delayed
       )
     end
 
-    def pending_run_ats_by_name
-      @memo[:pending_run_ats_by_name] ||= grouped_query(
-        jobs.pending,
-        include_db_time: true,
-        extra_group_columns: %i(name),
-        run_at: [:min, case_when(Job.claimable_clause.to_sql, 'run_at')],
-      )
-    end
-
-    def failed_counts
-      @memo[:failed_counts] ||= grouped_query(jobs.failed, count: [:count, '*'])
+    def failed_counts(attribute = nil)
+      @memo[[:failed_counts, attribute]] ||=
+        grouped_query(jobs.failed, extra_group_columns: [attribute].compact, count: [:count, '*'])
     end
 
     def db_now(record)

--- a/lib/delayed/monitor.rb
+++ b/lib/delayed/monitor.rb
@@ -116,28 +116,28 @@ module Delayed
     end
 
     # This method generates a query that scans the specified scope, groups by
-    # priority and queue (plus any extra_group_columns), and calculates the
+    # priority and queue (plus any tag_columns), and calculates the
     # specified aggregates. An outer query is executed for priority bucketing
     # and appending db_now_utc (to avoid running these computations for each
     # tuple in the inner query).
-    def grouped_query(scope, include_db_time: false, extra_group_columns: [], **kwargs)
+    def grouped_query(scope, include_db_time: false, **kwargs)
       inner_selects = kwargs.map { |key, (agg, expr)| as_expression(agg, expr, key) }
       outer_selects = kwargs.map { |key, (agg, _)| as_expression(agg == :count ? :sum : agg, key, key) }
       outer_selects << "#{self.class.sql_now_in_utc} AS db_now_utc" if include_db_time
 
       Delayed::Job
-        .from(scope.select(:priority, :queue, *extra_group_columns, *inner_selects).group(:priority, :queue, *extra_group_columns))
-        .group(priority_case_statement, :queue, *extra_group_columns).select(
+        .from(scope.select(:priority, :queue, *tag_columns, *inner_selects).group(:priority, :queue, *tag_columns))
+        .group(priority_case_statement, :queue, *tag_columns).select(
           *outer_selects,
           "#{priority_case_statement} AS priority",
           'queue AS queue',
-          *extra_group_columns.map { |column| "#{column} AS #{column}" },
-        ).group_by { |j| result_key(j, extra_group_columns) }
+          *tag_columns,
+        ).group_by { |j| result_key(j) }
         .transform_values(&:first)
     end
 
-    def result_key(record, extra_group_columns)
-      [record.priority.to_i, record.queue, *extra_group_columns.map { |column| record[column] }]
+    def result_key(record)
+      [record.priority.to_i, record.queue, *tag_columns.map { |column| record[column] }]
     end
 
     def as_expression(aggregate_function, aggregate_expression, column_name)
@@ -201,7 +201,6 @@ module Delayed
     def live_counts
       @memo[:live_counts] ||= grouped_query(
         jobs.live,
-        extra_group_columns: tag_columns,
         count: [:count, '*'],
         future_count: [:sum, case_when(Job.future_clause.to_sql)],
         erroring_count: [:sum, case_when(Job.erroring_clause.to_sql)],
@@ -212,7 +211,6 @@ module Delayed
       @memo[:pending_counts] ||= grouped_query(
         jobs.pending,
         include_db_time: true,
-        extra_group_columns: tag_columns,
         claimed_count: [:sum, case_when(Job.claimed_clause.to_sql)],
         claimable_count: [:sum, case_when(Job.claimable_clause.to_sql)],
         locked_at: [:min, case_when(Job.claimed_clause.to_sql, 'locked_at')],
@@ -222,7 +220,7 @@ module Delayed
 
     def failed_counts
       @memo[:failed_counts] ||=
-        grouped_query(jobs.failed, extra_group_columns: tag_columns, count: [:count, '*'])
+        grouped_query(jobs.failed, count: [:count, '*'])
     end
 
     def db_now(record)

--- a/lib/delayed/monitor.rb
+++ b/lib/delayed/monitor.rb
@@ -22,15 +22,11 @@ module Delayed
     end
 
     def self.tag_columns=(columns)
-      if columns.any? { |column| Job.column_names.exclude?(column.to_s) }
-        raise ArgumentError, "Delayed::Monitor.tag_columns includes columns missing from #{Job.table_name}. " \
-                             "Available columns: #{Job.column_names.join(', ')}"
-      end
-
       @tag_columns = columns.map(&:to_sym).freeze
     end
 
     def initialize
+      validate_tag_columns!
       @jobs = Job.group(:priority, :queue)
       @jobs = @jobs.where(queue: Worker.queues) if Worker.queues.any?
       @memo = {}
@@ -78,6 +74,13 @@ module Delayed
     private
 
     attr_reader :jobs
+
+    def validate_tag_columns!
+      if self.class.tag_columns.any? { |column| Job.column_names.exclude?(column.to_s) }
+        raise ArgumentError, "Delayed::Monitor.tag_columns includes columns missing from #{Job.table_name}. " \
+                             "Available columns: #{Job.column_names.join(', ')}"
+      end
+    end
 
     def emit_metric!(metric)
       query_for(metric)

--- a/lib/delayed/monitor.rb
+++ b/lib/delayed/monitor.rb
@@ -86,7 +86,7 @@ module Delayed
       query_for(metric)
         .merge!(default_results) { |_key, existing, _default| existing }
         .each do |(priority, queue, *column_values), value|
-        tags = column_values.zip(self.class.tag_columns).to_h { |val, column| [column, val.nil? ? 'unset' : val] }
+        tags = column_values.zip(self.class.tag_columns).to_h { |val, column| [column, val] }
         ActiveSupport::Notifications.instrument(
           "delayed.job.#{metric}",
           default_tags.merge(priority: Priority.new(priority).to_s, queue: queue, **tags, value: value),

--- a/lib/delayed/monitor.rb
+++ b/lib/delayed/monitor.rb
@@ -27,6 +27,7 @@ module Delayed
 
     def initialize
       validate_tag_columns!
+      @tag_columns = self.class.tag_columns
       @jobs = Job.group(:priority, :queue)
       @jobs = @jobs.where(queue: Worker.queues) if Worker.queues.any?
       @memo = {}
@@ -73,7 +74,7 @@ module Delayed
 
     private
 
-    attr_reader :jobs
+    attr_reader :jobs, :tag_columns
 
     def validate_tag_columns!
       if self.class.tag_columns.any? { |column| Job.column_names.exclude?(column.to_s) }
@@ -86,7 +87,7 @@ module Delayed
       query_for(metric)
         .merge!(default_results) { |_key, existing, _default| existing }
         .each do |(priority, queue, *column_values), value|
-        tags = column_values.zip(self.class.tag_columns).to_h { |val, column| [column, val] }
+        tags = column_values.zip(tag_columns).to_h { |val, column| [column, val] }
         ActiveSupport::Notifications.instrument(
           "delayed.job.#{metric}",
           default_tags.merge(priority: Priority.new(priority).to_s, queue: queue, **tags, value: value),
@@ -200,7 +201,7 @@ module Delayed
     def live_counts
       @memo[:live_counts] ||= grouped_query(
         jobs.live,
-        extra_group_columns: self.class.tag_columns,
+        extra_group_columns: tag_columns,
         count: [:count, '*'],
         future_count: [:sum, case_when(Job.future_clause.to_sql)],
         erroring_count: [:sum, case_when(Job.erroring_clause.to_sql)],
@@ -211,7 +212,7 @@ module Delayed
       @memo[:pending_counts] ||= grouped_query(
         jobs.pending,
         include_db_time: true,
-        extra_group_columns: self.class.tag_columns,
+        extra_group_columns: tag_columns,
         claimed_count: [:sum, case_when(Job.claimed_clause.to_sql)],
         claimable_count: [:sum, case_when(Job.claimable_clause.to_sql)],
         locked_at: [:min, case_when(Job.claimed_clause.to_sql, 'locked_at')],
@@ -221,7 +222,7 @@ module Delayed
 
     def failed_counts
       @memo[:failed_counts] ||=
-        grouped_query(jobs.failed, extra_group_columns: self.class.tag_columns, count: [:count, '*'])
+        grouped_query(jobs.failed, extra_group_columns: tag_columns, count: [:count, '*'])
     end
 
     def db_now(record)

--- a/lib/delayed/monitor.rb
+++ b/lib/delayed/monitor.rb
@@ -18,7 +18,7 @@ module Delayed
     cattr_accessor :sleep_delay, instance_writer: false, default: 60
 
     def self.tag_columns
-      @tag_columns ||= (Job.column_names.include?('name') ? %i(name) : []).freeze
+      @tag_columns ||= [].freeze
     end
 
     def self.tag_columns=(columns)

--- a/lib/delayed/version.rb
+++ b/lib/delayed/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Delayed
-  VERSION = '4.0.1'
+  VERSION = '4.1.0'
 end

--- a/spec/delayed/__snapshots__/monitor_spec.rb.snap
+++ b/spec/delayed/__snapshots__/monitor_spec.rb.snap
@@ -446,12 +446,13 @@ snapshots["runs the expected mysql2 queries with the expected plans 1"] = <<-SNA
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, COUNT(*) AS count
+       queue AS queue,
+       name AS name
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, COUNT(*) AS count
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NOT NULL
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -460,20 +461,21 @@ SELECT SUM(count) AS count,
                 -> Table scan on <temporary>
                     -> Aggregate using temporary table
                         -> Filter: (delayed_jobs.failed_at is not null)  (cost=...)
-                            -> Covering index range scan on delayed_jobs using idx_delayed_jobs_live over (NULL < failed_at)  (cost=...)
+                            -> Table scan on delayed_jobs  (cost=...)
 ---
 SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, COUNT(*) AS count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, COUNT(*) AS count,
        SUM(CASE WHEN `delayed_jobs`.`run_at` > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN `delayed_jobs`.`attempts` > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NULL
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -481,8 +483,7 @@ SELECT SUM(count) AS count,
             -> Materialize  (cost=...)
                 -> Table scan on <temporary>
                     -> Aggregate using temporary table
-                        -> Filter: (delayed_jobs.failed_at is null)  (cost=...)
-                            -> Covering index lookup on delayed_jobs using idx_delayed_jobs_live (failed_at = NULL)  (cost=...)
+                        -> Index lookup on delayed_jobs using idx_delayed_jobs_live (failed_at = NULL), with index condition: (delayed_jobs.failed_at is null)  (cost=...)
 ---
 -- QUERIES FOR `future_count`:
 ---------------------------------
@@ -495,8 +496,9 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        UTC_TIMESTAMP() AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, SUM(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, SUM(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (`delayed_jobs`.`locked_at` IS NULL
     OR `delayed_jobs`.`locked_at` < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -505,8 +507,8 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NULL
     AND `delayed_jobs`.`run_at` <= '2025-11-10 17:20:13'
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -514,8 +516,7 @@ SELECT SUM(claimed_count) AS claimed_count,
             -> Materialize  (cost=...)
                 -> Table scan on <temporary>
                     -> Aggregate using temporary table
-                        -> Filter: ((delayed_jobs.failed_at is null) and (delayed_jobs.run_at <= TIMESTAMP'2025-11-10 17:20:13'))  (cost=...)
-                            -> Covering index lookup on delayed_jobs using idx_delayed_jobs_live (failed_at = NULL)  (cost=...)
+                        -> Index lookup on delayed_jobs using idx_delayed_jobs_live (failed_at = NULL), with index condition: ((delayed_jobs.failed_at is null) and (delayed_jobs.run_at <= TIMESTAMP'2025-11-10 17:20:13'))  (cost=...)
 ---
 -- QUERIES FOR `erroring_count`:
 ---------------------------------
@@ -545,12 +546,13 @@ snapshots["[legacy index] runs the expected mysql2 queries with the expected pla
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, COUNT(*) AS count
+       queue AS queue,
+       name AS name
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, COUNT(*) AS count
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NOT NULL
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -565,14 +567,15 @@ SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, COUNT(*) AS count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, COUNT(*) AS count,
        SUM(CASE WHEN `delayed_jobs`.`run_at` > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN `delayed_jobs`.`attempts` > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NULL
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -594,8 +597,9 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        UTC_TIMESTAMP() AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, SUM(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, SUM(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (`delayed_jobs`.`locked_at` IS NULL
     OR `delayed_jobs`.`locked_at` < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -604,8 +608,8 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NULL
     AND `delayed_jobs`.`run_at` <= '2025-11-10 17:20:13'
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table

--- a/spec/delayed/__snapshots__/monitor_spec.rb.snap
+++ b/spec/delayed/__snapshots__/monitor_spec.rb.snap
@@ -3,121 +3,66 @@ snapshots["runs the expected postgresql queries with the expected plans 1"] = <<
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NOT NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Output: sum(subquery.count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.count
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.count
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.count
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.count
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, count(*)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue
-                    ->  Index Only Scan using idx_delayed_jobs_failed on public.delayed_jobs  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue
+                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, count(*)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                    ->  Sort  (cost=...)
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          ->  Index Scan using idx_delayed_jobs_failed on public.delayed_jobs  (cost=...)
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
 ---
 SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count,
        SUM(CASE WHEN \"delayed_jobs\".\"run_at\" > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN \"delayed_jobs\".\"attempts\" > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.count), sum(subquery.future_count), sum(subquery.erroring_count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Output: sum(subquery.count), sum(subquery.future_count), sum(subquery.erroring_count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.count, subquery.future_count, subquery.erroring_count
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.count, subquery.future_count, subquery.erroring_count
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.count, subquery.future_count, subquery.erroring_count
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.count, subquery.future_count, subquery.erroring_count
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, count(*), sum(CASE WHEN (delayed_jobs.run_at > '2025-11-10 17:20:13'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN (delayed_jobs.attempts > 0) THEN 1 ELSE 0 END)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue
+                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, count(*), sum(CASE WHEN (delayed_jobs.run_at > '2025-11-10 17:20:13'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN (delayed_jobs.attempts > 0) THEN 1 ELSE 0 END)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
                     ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.run_at, delayed_jobs.attempts
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
-                          ->  Index Only Scan using idx_delayed_jobs_live on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.run_at, delayed_jobs.attempts
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.run_at, delayed_jobs.attempts
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          ->  Index Scan using idx_delayed_jobs_live on public.delayed_jobs  (cost=...)
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.run_at, delayed_jobs.attempts
 ---
 -- QUERIES FOR `future_count`:
 ---------------------------------
 -- (no new queries)
 -- QUERIES FOR `locked_count`:
----------------------------------
-SELECT SUM(claimed_count) AS claimed_count,
-       SUM(claimable_count) AS claimable_count,
-       MIN(locked_at) AS locked_at,
-       MIN(run_at) AS run_at,
-       TIMEZONE('UTC', STATEMENT_TIMESTAMP()) AS db_now_utc,
-       CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
-       SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
-    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
-       MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
-       MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
-    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
-  FROM \"delayed_jobs\"
-  WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-    AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
-
-GroupAggregate  (cost=...)
-  Output: sum(subquery.claimed_count), sum(subquery.claimable_count), min(subquery.locked_at), min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-  ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-        ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
-              ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, sum(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN 1 ELSE 0 END), min(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN delayed_jobs.locked_at ELSE NULL::timestamp without time zone END), min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue
-                    ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.locked_at, delayed_jobs.run_at
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
-                          ->  Index Scan using idx_delayed_jobs_live on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.locked_at, delayed_jobs.run_at
-                                Index Cond: (delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone)
----
--- QUERIES FOR `erroring_count`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `failed_count`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `max_lock_age`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `max_age`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `working_count`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `workable_count`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `alert_age_percent`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `max_age_by_name`:
 ---------------------------------
 SELECT SUM(claimed_count) AS claimed_count,
        SUM(claimable_count) AS claimable_count,
@@ -157,6 +102,27 @@ GroupAggregate  (cost=...)
                                 Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
                                 Index Cond: (delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone)
 ---
+-- QUERIES FOR `erroring_count`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `failed_count`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `max_lock_age`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `max_age`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `working_count`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `workable_count`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `alert_age_percent`:
+---------------------------------
+-- (no new queries)
 SNAP
 
 snapshots["[legacy index] runs the expected postgresql queries with the expected plans 1"] = <<-SNAP
@@ -164,127 +130,68 @@ snapshots["[legacy index] runs the expected postgresql queries with the expected
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NOT NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Output: sum(subquery.count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.count
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.count
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.count
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.count
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, count(*)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue
+                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, count(*)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
                     ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
                           ->  Index Scan using delayed_jobs_priority on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
                                 Filter: (delayed_jobs.failed_at IS NOT NULL)
 ---
 SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count,
        SUM(CASE WHEN \"delayed_jobs\".\"run_at\" > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN \"delayed_jobs\".\"attempts\" > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.count), sum(subquery.future_count), sum(subquery.erroring_count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Output: sum(subquery.count), sum(subquery.future_count), sum(subquery.erroring_count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.count, subquery.future_count, subquery.erroring_count
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.count, subquery.future_count, subquery.erroring_count
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.count, subquery.future_count, subquery.erroring_count
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.count, subquery.future_count, subquery.erroring_count
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, count(*), sum(CASE WHEN (delayed_jobs.run_at > '2025-11-10 17:20:13'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN (delayed_jobs.attempts > 0) THEN 1 ELSE 0 END)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue
+                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, count(*), sum(CASE WHEN (delayed_jobs.run_at > '2025-11-10 17:20:13'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN (delayed_jobs.attempts > 0) THEN 1 ELSE 0 END)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
                     ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.run_at, delayed_jobs.attempts
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.run_at, delayed_jobs.attempts
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
                           ->  Index Scan using delayed_jobs_priority on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.run_at, delayed_jobs.attempts
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.run_at, delayed_jobs.attempts
                                 Filter: (delayed_jobs.failed_at IS NULL)
 ---
 -- QUERIES FOR `future_count`:
 ---------------------------------
 -- (no new queries)
 -- QUERIES FOR `locked_count`:
----------------------------------
-SELECT SUM(claimed_count) AS claimed_count,
-       SUM(claimable_count) AS claimable_count,
-       MIN(locked_at) AS locked_at,
-       MIN(run_at) AS run_at,
-       TIMEZONE('UTC', STATEMENT_TIMESTAMP()) AS db_now_utc,
-       CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
-       SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
-    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
-       MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
-       MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
-    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
-  FROM \"delayed_jobs\"
-  WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-    AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
-
-GroupAggregate  (cost=...)
-  Output: sum(subquery.claimed_count), sum(subquery.claimable_count), min(subquery.locked_at), min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-  ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
-        ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
-              ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, sum(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN 1 ELSE 0 END), min(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN delayed_jobs.locked_at ELSE NULL::timestamp without time zone END), min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue
-                    ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.locked_at, delayed_jobs.run_at
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
-                          ->  Index Scan using delayed_jobs_priority on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.locked_at, delayed_jobs.run_at
-                                Index Cond: (delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone)
-                                Filter: (delayed_jobs.failed_at IS NULL)
----
--- QUERIES FOR `erroring_count`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `failed_count`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `max_lock_age`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `max_age`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `working_count`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `workable_count`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `alert_age_percent`:
----------------------------------
--- (no new queries)
--- QUERIES FOR `max_age_by_name`:
 ---------------------------------
 SELECT SUM(claimed_count) AS claimed_count,
        SUM(claimable_count) AS claimable_count,
@@ -325,6 +232,27 @@ GroupAggregate  (cost=...)
                                 Index Cond: (delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone)
                                 Filter: (delayed_jobs.failed_at IS NULL)
 ---
+-- QUERIES FOR `erroring_count`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `failed_count`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `max_lock_age`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `max_age`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `working_count`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `workable_count`:
+---------------------------------
+-- (no new queries)
+-- QUERIES FOR `alert_age_percent`:
+---------------------------------
+-- (no new queries)
 SNAP
 
 snapshots["runs the expected sqlite3 queries with the expected plans 1"] = <<-SNAP
@@ -332,15 +260,17 @@ snapshots["runs the expected sqlite3 queries with the expected plans 1"] = <<-SN
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NOT NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX idx_delayed_jobs_failed
+USE TEMP B-TREE FOR GROUP BY
 SCAN subquery
 USE TEMP B-TREE FOR GROUP BY
 ---
@@ -348,14 +278,15 @@ SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count,
        SUM(CASE WHEN \"delayed_jobs\".\"run_at\" > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN \"delayed_jobs\".\"attempts\" > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX idx_delayed_jobs_live
@@ -374,8 +305,9 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        CURRENT_TIMESTAMP AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -384,8 +316,8 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
     AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX idx_delayed_jobs_live
@@ -414,34 +346,6 @@ USE TEMP B-TREE FOR GROUP BY
 -- QUERIES FOR `alert_age_percent`:
 ---------------------------------
 -- (no new queries)
--- QUERIES FOR `max_age_by_name`:
----------------------------------
-SELECT SUM(claimed_count) AS claimed_count,
-       SUM(claimable_count) AS claimable_count,
-       MIN(locked_at) AS locked_at,
-       MIN(run_at) AS run_at,
-       CURRENT_TIMESTAMP AS db_now_utc,
-       CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
-       SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
-    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
-       MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
-       MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
-    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
-  FROM \"delayed_jobs\"
-  WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-    AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
-
-CO-ROUTINE subquery
-SCAN delayed_jobs USING INDEX idx_delayed_jobs_live
-USE TEMP B-TREE FOR GROUP BY
-SCAN subquery
-USE TEMP B-TREE FOR GROUP BY
----
 SNAP
 
 snapshots["[legacy index] runs the expected sqlite3 queries with the expected plans 1"] = <<-SNAP
@@ -449,12 +353,13 @@ snapshots["[legacy index] runs the expected sqlite3 queries with the expected pl
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NOT NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX delayed_jobs_priority
@@ -466,14 +371,15 @@ SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count,
        SUM(CASE WHEN \"delayed_jobs\".\"run_at\" > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN \"delayed_jobs\".\"attempts\" > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX delayed_jobs_priority
@@ -492,8 +398,9 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        CURRENT_TIMESTAMP AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -502,8 +409,8 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
     AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX delayed_jobs_priority
@@ -532,34 +439,6 @@ USE TEMP B-TREE FOR GROUP BY
 -- QUERIES FOR `alert_age_percent`:
 ---------------------------------
 -- (no new queries)
--- QUERIES FOR `max_age_by_name`:
----------------------------------
-SELECT SUM(claimed_count) AS claimed_count,
-       SUM(claimable_count) AS claimable_count,
-       MIN(locked_at) AS locked_at,
-       MIN(run_at) AS run_at,
-       CURRENT_TIMESTAMP AS db_now_utc,
-       CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
-       SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
-    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
-       MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
-       MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
-    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
-  FROM \"delayed_jobs\"
-  WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-    AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
-
-CO-ROUTINE subquery
-SCAN delayed_jobs USING INDEX delayed_jobs_priority
-USE TEMP B-TREE FOR GROUP BY
-SCAN subquery
-USE TEMP B-TREE FOR GROUP BY
----
 SNAP
 
 snapshots["runs the expected mysql2 queries with the expected plans 1"] = <<-SNAP

--- a/spec/delayed/__snapshots__/monitor_spec.rb.snap
+++ b/spec/delayed/__snapshots__/monitor_spec.rb.snap
@@ -119,12 +119,19 @@ GroupAggregate  (cost=...)
 -- (no new queries)
 -- QUERIES FOR `max_age_by_name`:
 ---------------------------------
-SELECT MIN(run_at) AS run_at,
+SELECT SUM(claimed_count) AS claimed_count,
+       SUM(claimable_count) AS claimable_count,
+       MIN(locked_at) AS locked_at,
+       MIN(run_at) AS run_at,
        TIMEZONE('UTC', STATEMENT_TIMESTAMP()) AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
        queue AS queue,
        name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
+       MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
+       MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
@@ -133,15 +140,15 @@ SELECT MIN(run_at) AS run_at,
   GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 GroupAggregate  (cost=...)
-  Output: min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Output: sum(subquery.claimed_count), sum(subquery.claimable_count), min(subquery.locked_at), min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
   Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.run_at
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
         Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.run_at
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
+                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, sum(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN 1 ELSE 0 END), min(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN delayed_jobs.locked_at ELSE NULL::timestamp without time zone END), min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
                     Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
                     ->  Sort  (cost=...)
                           Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
@@ -279,12 +286,19 @@ GroupAggregate  (cost=...)
 -- (no new queries)
 -- QUERIES FOR `max_age_by_name`:
 ---------------------------------
-SELECT MIN(run_at) AS run_at,
+SELECT SUM(claimed_count) AS claimed_count,
+       SUM(claimable_count) AS claimable_count,
+       MIN(locked_at) AS locked_at,
+       MIN(run_at) AS run_at,
        TIMEZONE('UTC', STATEMENT_TIMESTAMP()) AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
        queue AS queue,
        name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
+       MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
+       MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
@@ -293,15 +307,15 @@ SELECT MIN(run_at) AS run_at,
   GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
 
 GroupAggregate  (cost=...)
-  Output: min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Output: sum(subquery.claimed_count), sum(subquery.claimable_count), min(subquery.locked_at), min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
   Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.run_at
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
         Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.run_at
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
+                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, sum(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN 1 ELSE 0 END), min(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN delayed_jobs.locked_at ELSE NULL::timestamp without time zone END), min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
                     Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
                     ->  Sort  (cost=...)
                           Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
@@ -402,12 +416,19 @@ USE TEMP B-TREE FOR GROUP BY
 -- (no new queries)
 -- QUERIES FOR `max_age_by_name`:
 ---------------------------------
-SELECT MIN(run_at) AS run_at,
+SELECT SUM(claimed_count) AS claimed_count,
+       SUM(claimable_count) AS claimable_count,
+       MIN(locked_at) AS locked_at,
+       MIN(run_at) AS run_at,
        CURRENT_TIMESTAMP AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
        queue AS queue,
        name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
+       MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
+       MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
@@ -513,12 +534,19 @@ USE TEMP B-TREE FOR GROUP BY
 -- (no new queries)
 -- QUERIES FOR `max_age_by_name`:
 ---------------------------------
-SELECT MIN(run_at) AS run_at,
+SELECT SUM(claimed_count) AS claimed_count,
+       SUM(claimable_count) AS claimable_count,
+       MIN(locked_at) AS locked_at,
+       MIN(run_at) AS run_at,
        CURRENT_TIMESTAMP AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
        queue AS queue,
        name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
+       MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
+       MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL

--- a/spec/delayed/__snapshots__/monitor_spec.rb.snap
+++ b/spec/delayed/__snapshots__/monitor_spec.rb.snap
@@ -117,6 +117,39 @@ GroupAggregate  (cost=...)
 -- QUERIES FOR `alert_age_percent`:
 ---------------------------------
 -- (no new queries)
+-- QUERIES FOR `max_age_by_name`:
+---------------------------------
+SELECT MIN(run_at) AS run_at,
+       TIMEZONE('UTC', STATEMENT_TIMESTAMP()) AS db_now_utc,
+       CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
+  FROM \"delayed_jobs\"
+  WHERE \"delayed_jobs\".\"failed_at\" IS NULL
+    AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+
+GroupAggregate  (cost=...)
+  Output: min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  ->  Sort  (cost=...)
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.run_at
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+        ->  Subquery Scan on subquery  (cost=...)
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.run_at
+              ->  GroupAggregate  (cost=...)
+                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                    ->  Sort  (cost=...)
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          ->  Index Scan using idx_delayed_jobs_live on public.delayed_jobs  (cost=...)
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
+                                Index Cond: (delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone)
+---
 SNAP
 
 snapshots["[legacy index] runs the expected postgresql queries with the expected plans 1"] = <<-SNAP
@@ -244,6 +277,40 @@ GroupAggregate  (cost=...)
 -- QUERIES FOR `alert_age_percent`:
 ---------------------------------
 -- (no new queries)
+-- QUERIES FOR `max_age_by_name`:
+---------------------------------
+SELECT MIN(run_at) AS run_at,
+       TIMEZONE('UTC', STATEMENT_TIMESTAMP()) AS db_now_utc,
+       CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
+  FROM \"delayed_jobs\"
+  WHERE \"delayed_jobs\".\"failed_at\" IS NULL
+    AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+
+GroupAggregate  (cost=...)
+  Output: min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  ->  Sort  (cost=...)
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.run_at
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+        ->  Subquery Scan on subquery  (cost=...)
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.run_at
+              ->  GroupAggregate  (cost=...)
+                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                    ->  Sort  (cost=...)
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          ->  Index Scan using delayed_jobs_priority on public.delayed_jobs  (cost=...)
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
+                                Index Cond: (delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone)
+                                Filter: (delayed_jobs.failed_at IS NULL)
+---
 SNAP
 
 snapshots["runs the expected sqlite3 queries with the expected plans 1"] = <<-SNAP
@@ -333,6 +400,27 @@ USE TEMP B-TREE FOR GROUP BY
 -- QUERIES FOR `alert_age_percent`:
 ---------------------------------
 -- (no new queries)
+-- QUERIES FOR `max_age_by_name`:
+---------------------------------
+SELECT MIN(run_at) AS run_at,
+       CURRENT_TIMESTAMP AS db_now_utc,
+       CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
+  FROM \"delayed_jobs\"
+  WHERE \"delayed_jobs\".\"failed_at\" IS NULL
+    AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+
+CO-ROUTINE subquery
+SCAN delayed_jobs USING INDEX idx_delayed_jobs_live
+USE TEMP B-TREE FOR GROUP BY
+SCAN subquery
+USE TEMP B-TREE FOR GROUP BY
+---
 SNAP
 
 snapshots["[legacy index] runs the expected sqlite3 queries with the expected plans 1"] = <<-SNAP
@@ -423,6 +511,27 @@ USE TEMP B-TREE FOR GROUP BY
 -- QUERIES FOR `alert_age_percent`:
 ---------------------------------
 -- (no new queries)
+-- QUERIES FOR `max_age_by_name`:
+---------------------------------
+SELECT MIN(run_at) AS run_at,
+       CURRENT_TIMESTAMP AS db_now_utc,
+       CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
+       queue AS queue,
+       name AS name
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", MIN(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
+    OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN run_at ELSE NULL END) AS run_at
+  FROM \"delayed_jobs\"
+  WHERE \"delayed_jobs\".\"failed_at\" IS NULL
+    AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+
+CO-ROUTINE subquery
+SCAN delayed_jobs USING INDEX delayed_jobs_priority
+USE TEMP B-TREE FOR GROUP BY
+SCAN subquery
+USE TEMP B-TREE FOR GROUP BY
+---
 SNAP
 
 snapshots["runs the expected mysql2 queries with the expected plans 1"] = <<-SNAP

--- a/spec/delayed/__snapshots__/monitor_spec.rb.snap
+++ b/spec/delayed/__snapshots__/monitor_spec.rb.snap
@@ -3,61 +3,56 @@ snapshots["runs the expected postgresql queries with the expected plans 1"] = <<
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NOT NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Output: sum(subquery.count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.count
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.count
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.count
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.count
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, count(*)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
-                    ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
-                          ->  Index Scan using idx_delayed_jobs_failed on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                    Output: delayed_jobs.priority, delayed_jobs.queue, count(*)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue
+                    ->  Index Only Scan using idx_delayed_jobs_failed on public.delayed_jobs  (cost=...)
+                          Output: delayed_jobs.priority, delayed_jobs.queue
 ---
 SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count,
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count,
        SUM(CASE WHEN \"delayed_jobs\".\"run_at\" > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN \"delayed_jobs\".\"attempts\" > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.count), sum(subquery.future_count), sum(subquery.erroring_count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Output: sum(subquery.count), sum(subquery.future_count), sum(subquery.erroring_count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.count, subquery.future_count, subquery.erroring_count
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.count, subquery.future_count, subquery.erroring_count
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.count, subquery.future_count, subquery.erroring_count
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.count, subquery.future_count, subquery.erroring_count
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, count(*), sum(CASE WHEN (delayed_jobs.run_at > '2025-11-10 17:20:13'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN (delayed_jobs.attempts > 0) THEN 1 ELSE 0 END)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                    Output: delayed_jobs.priority, delayed_jobs.queue, count(*), sum(CASE WHEN (delayed_jobs.run_at > '2025-11-10 17:20:13'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN (delayed_jobs.attempts > 0) THEN 1 ELSE 0 END)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue
                     ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.run_at, delayed_jobs.attempts
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
-                          ->  Index Scan using idx_delayed_jobs_live on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.run_at, delayed_jobs.attempts
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.run_at, delayed_jobs.attempts
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
+                          ->  Index Only Scan using idx_delayed_jobs_live on public.delayed_jobs  (cost=...)
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.run_at, delayed_jobs.attempts
 ---
 -- QUERIES FOR `future_count`:
 ---------------------------------
@@ -70,9 +65,8 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        TIMEZONE('UTC', STATEMENT_TIMESTAMP()) AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -81,25 +75,25 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
     AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.claimed_count), sum(subquery.claimable_count), min(subquery.locked_at), min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Output: sum(subquery.claimed_count), sum(subquery.claimable_count), min(subquery.locked_at), min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, sum(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN 1 ELSE 0 END), min(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN delayed_jobs.locked_at ELSE NULL::timestamp without time zone END), min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                    Output: delayed_jobs.priority, delayed_jobs.queue, sum(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN 1 ELSE 0 END), min(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN delayed_jobs.locked_at ELSE NULL::timestamp without time zone END), min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue
                     ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.locked_at, delayed_jobs.run_at
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
                           ->  Index Scan using idx_delayed_jobs_live on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.locked_at, delayed_jobs.run_at
                                 Index Cond: (delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone)
 ---
 -- QUERIES FOR `erroring_count`:
@@ -130,62 +124,60 @@ snapshots["[legacy index] runs the expected postgresql queries with the expected
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NOT NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Output: sum(subquery.count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.count
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.count
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.count
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.count
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, count(*)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                    Output: delayed_jobs.priority, delayed_jobs.queue, count(*)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue
                     ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          Output: delayed_jobs.priority, delayed_jobs.queue
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
                           ->  Index Scan using delayed_jobs_priority on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                                Output: delayed_jobs.priority, delayed_jobs.queue
                                 Filter: (delayed_jobs.failed_at IS NOT NULL)
 ---
 SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count,
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count,
        SUM(CASE WHEN \"delayed_jobs\".\"run_at\" > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN \"delayed_jobs\".\"attempts\" > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.count), sum(subquery.future_count), sum(subquery.erroring_count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Output: sum(subquery.count), sum(subquery.future_count), sum(subquery.erroring_count), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.count, subquery.future_count, subquery.erroring_count
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.count, subquery.future_count, subquery.erroring_count
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.count, subquery.future_count, subquery.erroring_count
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.count, subquery.future_count, subquery.erroring_count
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, count(*), sum(CASE WHEN (delayed_jobs.run_at > '2025-11-10 17:20:13'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN (delayed_jobs.attempts > 0) THEN 1 ELSE 0 END)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                    Output: delayed_jobs.priority, delayed_jobs.queue, count(*), sum(CASE WHEN (delayed_jobs.run_at > '2025-11-10 17:20:13'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN (delayed_jobs.attempts > 0) THEN 1 ELSE 0 END)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue
                     ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.run_at, delayed_jobs.attempts
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.run_at, delayed_jobs.attempts
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
                           ->  Index Scan using delayed_jobs_priority on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.run_at, delayed_jobs.attempts
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.run_at, delayed_jobs.attempts
                                 Filter: (delayed_jobs.failed_at IS NULL)
 ---
 -- QUERIES FOR `future_count`:
@@ -199,9 +191,8 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        TIMEZONE('UTC', STATEMENT_TIMESTAMP()) AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -210,25 +201,25 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
     AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 GroupAggregate  (cost=...)
-  Output: sum(subquery.claimed_count), sum(subquery.claimable_count), min(subquery.locked_at), min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
-  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+  Output: sum(subquery.claimed_count), sum(subquery.claimable_count), min(subquery.locked_at), min(subquery.run_at), timezone('UTC'::text, statement_timestamp()), (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
+  Group Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
   ->  Sort  (cost=...)
-        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
-        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.name
+        Output: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
+        Sort Key: (CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END), subquery.queue
         ->  Subquery Scan on subquery  (cost=...)
-              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.name, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
+              Output: CASE WHEN (subquery.priority < 10) THEN 0 WHEN (subquery.priority < 20) THEN 10 WHEN (subquery.priority < 30) THEN 20 WHEN (subquery.priority >= 30) THEN 30 ELSE NULL::integer END, subquery.queue, subquery.claimed_count, subquery.claimable_count, subquery.locked_at, subquery.run_at
               ->  GroupAggregate  (cost=...)
-                    Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, sum(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN 1 ELSE 0 END), min(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN delayed_jobs.locked_at ELSE NULL::timestamp without time zone END), min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
-                    Group Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                    Output: delayed_jobs.priority, delayed_jobs.queue, sum(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN 1 ELSE 0 END), sum(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN 1 ELSE 0 END), min(CASE WHEN (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone) THEN delayed_jobs.locked_at ELSE NULL::timestamp without time zone END), min(CASE WHEN ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone)) THEN delayed_jobs.run_at ELSE NULL::timestamp without time zone END)
+                    Group Key: delayed_jobs.priority, delayed_jobs.queue
                     ->  Sort  (cost=...)
-                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
-                          Sort Key: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name
+                          Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.locked_at, delayed_jobs.run_at
+                          Sort Key: delayed_jobs.priority, delayed_jobs.queue
                           ->  Index Scan using delayed_jobs_priority on public.delayed_jobs  (cost=...)
-                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.name, delayed_jobs.locked_at, delayed_jobs.run_at
+                                Output: delayed_jobs.priority, delayed_jobs.queue, delayed_jobs.locked_at, delayed_jobs.run_at
                                 Index Cond: (delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone)
                                 Filter: (delayed_jobs.failed_at IS NULL)
 ---
@@ -260,17 +251,15 @@ snapshots["runs the expected sqlite3 queries with the expected plans 1"] = <<-SN
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NOT NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX idx_delayed_jobs_failed
-USE TEMP B-TREE FOR GROUP BY
 SCAN subquery
 USE TEMP B-TREE FOR GROUP BY
 ---
@@ -278,15 +267,14 @@ SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count,
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count,
        SUM(CASE WHEN \"delayed_jobs\".\"run_at\" > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN \"delayed_jobs\".\"attempts\" > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX idx_delayed_jobs_live
@@ -305,9 +293,8 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        CURRENT_TIMESTAMP AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -316,8 +303,8 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
     AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX idx_delayed_jobs_live
@@ -353,13 +340,12 @@ snapshots["[legacy index] runs the expected sqlite3 queries with the expected pl
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NOT NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX delayed_jobs_priority
@@ -371,15 +357,14 @@ SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", COUNT(*) AS count,
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", COUNT(*) AS count,
        SUM(CASE WHEN \"delayed_jobs\".\"run_at\" > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN \"delayed_jobs\".\"attempts\" > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX delayed_jobs_priority
@@ -398,9 +383,8 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        CURRENT_TIMESTAMP AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue
+  FROM (SELECT \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", SUM(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (\"delayed_jobs\".\"locked_at\" IS NULL
     OR \"delayed_jobs\".\"locked_at\" < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN \"delayed_jobs\".\"locked_at\" >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -409,8 +393,8 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM \"delayed_jobs\"
   WHERE \"delayed_jobs\".\"failed_at\" IS NULL
     AND \"delayed_jobs\".\"run_at\" <= '2025-11-10 17:20:13'
-  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\", \"delayed_jobs\".\"name\") subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\", \"name\"
+  GROUP BY \"delayed_jobs\".\"priority\", \"delayed_jobs\".\"queue\") subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, \"queue\"
 
 CO-ROUTINE subquery
 SCAN delayed_jobs USING INDEX delayed_jobs_priority
@@ -446,13 +430,12 @@ snapshots["runs the expected mysql2 queries with the expected plans 1"] = <<-SNA
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, COUNT(*) AS count
+       queue AS queue
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, COUNT(*) AS count
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NOT NULL
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -461,21 +444,20 @@ SELECT SUM(count) AS count,
                 -> Table scan on <temporary>
                     -> Aggregate using temporary table
                         -> Filter: (delayed_jobs.failed_at is not null)  (cost=...)
-                            -> Table scan on delayed_jobs  (cost=...)
+                            -> Covering index range scan on delayed_jobs using idx_delayed_jobs_live over (NULL < failed_at)  (cost=...)
 ---
 SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, COUNT(*) AS count,
+       queue AS queue
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, COUNT(*) AS count,
        SUM(CASE WHEN `delayed_jobs`.`run_at` > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN `delayed_jobs`.`attempts` > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NULL
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -483,7 +465,8 @@ SELECT SUM(count) AS count,
             -> Materialize  (cost=...)
                 -> Table scan on <temporary>
                     -> Aggregate using temporary table
-                        -> Index lookup on delayed_jobs using idx_delayed_jobs_live (failed_at = NULL), with index condition: (delayed_jobs.failed_at is null)  (cost=...)
+                        -> Filter: (delayed_jobs.failed_at is null)  (cost=...)
+                            -> Covering index lookup on delayed_jobs using idx_delayed_jobs_live (failed_at = NULL)  (cost=...)
 ---
 -- QUERIES FOR `future_count`:
 ---------------------------------
@@ -496,9 +479,8 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        UTC_TIMESTAMP() AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, SUM(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, SUM(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (`delayed_jobs`.`locked_at` IS NULL
     OR `delayed_jobs`.`locked_at` < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -507,8 +489,8 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NULL
     AND `delayed_jobs`.`run_at` <= '2025-11-10 17:20:13'
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -516,7 +498,8 @@ SELECT SUM(claimed_count) AS claimed_count,
             -> Materialize  (cost=...)
                 -> Table scan on <temporary>
                     -> Aggregate using temporary table
-                        -> Index lookup on delayed_jobs using idx_delayed_jobs_live (failed_at = NULL), with index condition: ((delayed_jobs.failed_at is null) and (delayed_jobs.run_at <= TIMESTAMP'2025-11-10 17:20:13'))  (cost=...)
+                        -> Filter: ((delayed_jobs.failed_at is null) and (delayed_jobs.run_at <= TIMESTAMP'2025-11-10 17:20:13'))  (cost=...)
+                            -> Covering index lookup on delayed_jobs using idx_delayed_jobs_live (failed_at = NULL)  (cost=...)
 ---
 -- QUERIES FOR `erroring_count`:
 ---------------------------------
@@ -546,13 +529,12 @@ snapshots["[legacy index] runs the expected mysql2 queries with the expected pla
 ---------------------------------
 SELECT SUM(count) AS count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, COUNT(*) AS count
+       queue AS queue
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, COUNT(*) AS count
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NOT NULL
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -567,15 +549,14 @@ SELECT SUM(count) AS count,
        SUM(future_count) AS future_count,
        SUM(erroring_count) AS erroring_count,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, COUNT(*) AS count,
+       queue AS queue
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, COUNT(*) AS count,
        SUM(CASE WHEN `delayed_jobs`.`run_at` > '2025-11-10 17:20:13' THEN 1 ELSE 0 END) AS future_count,
        SUM(CASE WHEN `delayed_jobs`.`attempts` > 0 THEN 1 ELSE 0 END) AS erroring_count
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NULL
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table
@@ -597,9 +578,8 @@ SELECT SUM(claimed_count) AS claimed_count,
        MIN(run_at) AS run_at,
        UTC_TIMESTAMP() AS db_now_utc,
        CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END AS priority,
-       queue AS queue,
-       name AS name
-  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`, SUM(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
+       queue AS queue
+  FROM (SELECT `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, SUM(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN 1 ELSE 0 END) AS claimed_count,
        SUM(CASE WHEN (`delayed_jobs`.`locked_at` IS NULL
     OR `delayed_jobs`.`locked_at` < '2025-11-10 16:59:43') THEN 1 ELSE 0 END) AS claimable_count,
        MIN(CASE WHEN `delayed_jobs`.`locked_at` >= '2025-11-10 16:59:43' THEN locked_at ELSE NULL END) AS locked_at,
@@ -608,8 +588,8 @@ SELECT SUM(claimed_count) AS claimed_count,
   FROM `delayed_jobs`
   WHERE `delayed_jobs`.`failed_at` IS NULL
     AND `delayed_jobs`.`run_at` <= '2025-11-10 17:20:13'
-  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`, `delayed_jobs`.`name`) subquery
-  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`, `name`
+  GROUP BY `delayed_jobs`.`priority`, `delayed_jobs`.`queue`) subquery
+  GROUP BY CASE WHEN priority < 10 THEN 0 WHEN priority < 20 THEN 10 WHEN priority < 30 THEN 20 WHEN priority >= 30 THEN 30 END, `queue`
 
 -> Table scan on <temporary>
     -> Aggregate using temporary table

--- a/spec/delayed/monitor_spec.rb
+++ b/spec/delayed/monitor_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe Delayed::Monitor do
     described_class.sleep_delay = 0
   end
 
+  def emitted_event_names(pattern, &block)
+    events = []
+    callback = ->(name, *) { events << name }
+    ActiveSupport::Notifications.subscribed(callback, pattern, &block)
+    events
+  end
+
   let(:default_payload) do
     {
       table: 'delayed_jobs',
@@ -81,6 +88,10 @@ RSpec.describe Delayed::Monitor do
         .and emit_notification("delayed.job.alert_age_percent").with_payload(default_payload.merge(priority: 'user_visible')).approximately.with_value(0)
         .and emit_notification("delayed.job.alert_age_percent").with_payload(default_payload.merge(priority: 'eventual')).approximately.with_value(0)
         .and emit_notification("delayed.job.alert_age_percent").with_payload(default_payload.merge(priority: 'reporting')).approximately.with_value(0)
+    end
+
+    it 'does not emit max_age_by_name when no jobs are present' do
+      expect(emitted_event_names("delayed.job.max_age_by_name") { subject.run! }).to be_empty
     end
 
     context 'when named priorities are customized' do
@@ -199,6 +210,67 @@ RSpec.describe Delayed::Monitor do
           .and emit_notification("delayed.job.alert_age_percent").with_payload(p30_payload).approximately.with_value(100) # 6 hours / 4 hours (overflow)
           .and emit_notification("delayed.job.workable_count").with_payload(p30_payload.merge(queue: 'banana')).with_value(1)
           .and emit_notification("delayed.job.max_age").with_payload(p30_payload.merge(queue: 'banana')).approximately.with_value(4.hours)
+      end
+
+      it 'emits max_age_by_name grouped by job name' do
+        expect { subject.run! }
+          .to emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'SimpleJob')).approximately.with_value(30.seconds)
+          .and emit_notification("delayed.job.max_age_by_name").with_payload(p10_payload.merge(name: 'SimpleJob')).approximately.with_value(2.minutes)
+          .and emit_notification("delayed.job.max_age_by_name").with_payload(p20_payload.merge(name: 'SimpleJob')).approximately.with_value(1.hour)
+          .and emit_notification("delayed.job.max_age_by_name").with_payload(p30_payload.merge(name: 'SimpleJob')).approximately.with_value(6.hours)
+          .and emit_notification("delayed.job.max_age_by_name").with_payload(p30_payload.merge(queue: 'banana', name: 'SimpleJob')).approximately.with_value(4.hours)
+      end
+
+      context 'when multiple job names share a priority and queue' do
+        let!(:other_named_job) { Delayed::Job.create! p0_attributes.merge(name: 'OtherJob', run_at: now - 10.minutes) }
+
+        it 'emits a separate max_age_by_name series per name' do
+          expect { subject.run! }
+            .to emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'SimpleJob')).approximately.with_value(30.seconds)
+            .and emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'OtherJob')).approximately.with_value(10.minutes)
+        end
+      end
+
+      context 'when emit_max_age_by_name is disabled' do
+        around do |example|
+          described_class.emit_max_age_by_name = false
+          example.run
+        ensure
+          described_class.emit_max_age_by_name = true
+        end
+
+        it 'does not emit max_age_by_name' do
+          expect(emitted_event_names("delayed.job.max_age_by_name") { subject.run! }).to be_empty
+        end
+      end
+
+      context 'when the delayed_jobs table has no name column' do
+        before do
+          allow(Delayed::Job).to receive(:name_assignable?).and_return(false)
+        end
+
+        it 'does not emit max_age_by_name' do
+          expect(emitted_event_names("delayed.job.max_age_by_name") { subject.run! }).to be_empty
+        end
+      end
+
+      context 'when a job predates the name column' do
+        around do |example|
+          ValidateRunAtAndNameNotNull.migrate(:down)
+          AddRunAtAndNameNotNullCheck.migrate(:down)
+          example.run
+        ensure
+          Delayed::Job.delete_all
+          AddRunAtAndNameNotNullCheck.migrate(:up)
+          ValidateRunAtAndNameNotNull.migrate(:up)
+        end
+
+        let!(:unnamed_job) { Delayed::Job.create! p0_attributes.merge(name: nil, run_at: now - 10.minutes) }
+
+        it "emits max_age_by_name under the name 'unknown'" do
+          expect { subject.run! }
+            .to emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'unknown')).approximately.with_value(10.minutes)
+        end
       end
 
       context 'when named priorities are customized' do
@@ -369,6 +441,11 @@ RSpec.describe Delayed::Monitor do
           .and emit_notification("delayed.job.alert_age_percent").with_payload(payload).approximately.with_value(0)
       end
 
+      it 'excludes the locked job from max_age_by_name' do
+        expect { subject.run! }
+          .to emit_notification("delayed.job.max_age_by_name").with_payload(payload.merge(name: 'SimpleJob')).approximately.with_value(0)
+      end
+
       context 'and a workable job is also present in the same group' do
         # The workable job's run_at is newer than the locked job's, so max_age must
         # track the workable job (30s), not the locked job (1 hour).
@@ -405,7 +482,7 @@ RSpec.describe Delayed::Monitor do
     end
 
     def query_descriptions
-      described_class::METRICS.each do |metric|
+      (described_class::METRICS + %w(max_age_by_name)).each do |metric|
         queries << "-- QUERIES FOR `#{metric}`:"
         queries << "---------------------------------"
         monitor.query_for(metric)

--- a/spec/delayed/monitor_spec.rb
+++ b/spec/delayed/monitor_spec.rb
@@ -231,12 +231,12 @@ RSpec.describe Delayed::Monitor do
         end
       end
 
-      context 'when emit_max_age_by_name is disabled' do
+      context 'when metrics_by_attribute is empty' do
         around do |example|
-          described_class.emit_max_age_by_name = false
+          described_class.metrics_by_attribute = {}
           example.run
         ensure
-          described_class.emit_max_age_by_name = true
+          described_class.metrics_by_attribute = { max_age: %i(name) }
         end
 
         it 'does not emit max_age_by_name' do
@@ -246,7 +246,7 @@ RSpec.describe Delayed::Monitor do
 
       context 'when the delayed_jobs table has no name column' do
         before do
-          allow(Delayed::Job).to receive(:name_assignable?).and_return(false)
+          allow(Delayed::Job).to receive(:column_names).and_return(Delayed::Job.column_names - ['name'])
         end
 
         it 'does not emit max_age_by_name' do
@@ -270,6 +270,54 @@ RSpec.describe Delayed::Monitor do
         it "emits max_age_by_name under the name 'unknown'" do
           expect { subject.run! }
             .to emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'unknown')).approximately.with_value(10.minutes)
+        end
+      end
+
+      context 'when metrics_by_attribute pairs metrics with a custom column' do
+        around do |example|
+          Delayed::Job.connection.add_column :delayed_jobs, :owner, :string
+          Delayed::Job.reset_column_information
+          described_class.metrics_by_attribute = { max_age: %i(name owner), failed_count: %i(owner) }
+          example.run
+        ensure
+          described_class.metrics_by_attribute = { max_age: %i(name) }
+          Delayed::Job.connection.remove_column :delayed_jobs, :owner
+          Delayed::Job.reset_column_information
+        end
+
+        let!(:team_a_job) { Delayed::Job.create! p0_attributes.merge(owner: 'team_a', run_at: now - 10.minutes) }
+        let!(:team_b_job) { Delayed::Job.create! p0_attributes.merge(owner: 'team_b', run_at: now - 20.minutes) }
+
+        it "emits a max_age_by_owner series per owner, reporting ownerless rows as 'unknown'" do
+          expect { subject.run! }
+            .to emit_notification("delayed.job.max_age_by_owner").with_payload(p0_payload.merge(owner: 'team_a')).approximately.with_value(10.minutes)
+            .and emit_notification("delayed.job.max_age_by_owner").with_payload(p0_payload.merge(owner: 'team_b')).approximately.with_value(20.minutes)
+            .and emit_notification("delayed.job.max_age_by_owner").with_payload(p0_payload.merge(owner: 'unknown')).approximately.with_value(30.seconds)
+        end
+
+        it 'emits other paired metrics by the same column' do
+          expect { subject.run! }
+            .to emit_notification("delayed.job.failed_count_by_owner").with_payload(p0_payload.merge(owner: 'unknown')).with_value(1)
+        end
+
+        it 'emits max_age_by_name independently, without owner tags' do
+          expect { subject.run! }
+            .to emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'SimpleJob')).approximately.with_value(20.minutes)
+        end
+      end
+
+      context 'when metrics_by_attribute names a column that does not exist' do
+        around do |example|
+          described_class.metrics_by_attribute = { max_age: %i(name owner) }
+          example.run
+        ensure
+          described_class.metrics_by_attribute = { max_age: %i(name) }
+        end
+
+        it 'skips the missing column but still emits max_age_by_name' do
+          events = emitted_event_names(/delayed\.job\.max_age_by_/) { subject.run! }
+          expect(events).to include("delayed.job.max_age_by_name")
+          expect(events).not_to include("delayed.job.max_age_by_owner")
         end
       end
 
@@ -461,6 +509,13 @@ RSpec.describe Delayed::Monitor do
     end
   end
 
+  describe '.metrics_by_attribute=' do
+    it 'rejects unknown metrics at assignment time' do
+      expect { described_class.metrics_by_attribute = { min_age: %i(name) } }
+        .to raise_error(ArgumentError, /Unknown metrics in metrics_by_attribute: min_age/)
+    end
+  end
+
   describe 'SQL' do
     let(:monitor) { described_class.new }
     let(:queries) { [] }
@@ -485,7 +540,8 @@ RSpec.describe Delayed::Monitor do
       (described_class::METRICS + %w(max_age_by_name)).each do |metric|
         queries << "-- QUERIES FOR `#{metric}`:"
         queries << "---------------------------------"
-        monitor.query_for(metric)
+        base, attribute = metric.split('_by_')
+        monitor.query_for(base, *[attribute&.to_sym].compact)
         queries << "-- (no new queries)" unless queries.last == '---'
       end
       queries.dup.map { |query| query.try(:full_description) || query }

--- a/spec/delayed/monitor_spec.rb
+++ b/spec/delayed/monitor_spec.rb
@@ -5,13 +5,6 @@ RSpec.describe Delayed::Monitor do
     described_class.sleep_delay = 0
   end
 
-  def emitted_event_names(pattern, &block)
-    events = []
-    callback = ->(name, *) { events << name }
-    ActiveSupport::Notifications.subscribed(callback, pattern, &block)
-    events
-  end
-
   let(:default_payload) do
     {
       table: 'delayed_jobs',
@@ -90,10 +83,6 @@ RSpec.describe Delayed::Monitor do
         .and emit_notification("delayed.job.alert_age_percent").with_payload(default_payload.merge(priority: 'reporting')).approximately.with_value(0)
     end
 
-    it 'does not emit max_age_by_name when no jobs are present' do
-      expect(emitted_event_names("delayed.job.max_age_by_name") { subject.run! }).to be_empty
-    end
-
     context 'when named priorities are customized' do
       around do |example|
         Delayed::Priority.names = { high: 0, low: 7 }
@@ -143,10 +132,10 @@ RSpec.describe Delayed::Monitor do
       let(:p10_attributes) { job_attributes.merge(priority: 13, locked_at: now - 1.day) }
       let(:p20_attributes) { job_attributes.merge(priority: 23, attempts: 1) }
       let(:p30_attributes) { job_attributes.merge(priority: 999, locked_at: now - 1.day) }
-      let(:p0_payload) { default_payload.merge(priority: 'interactive') }
-      let(:p10_payload) { default_payload.merge(priority: 'user_visible') }
-      let(:p20_payload) { default_payload.merge(priority: 'eventual') }
-      let(:p30_payload) { default_payload.merge(priority: 'reporting') }
+      let(:p0_payload) { default_payload.merge(priority: 'interactive', name: 'SimpleJob') }
+      let(:p10_payload) { default_payload.merge(priority: 'user_visible', name: 'SimpleJob') }
+      let(:p20_payload) { default_payload.merge(priority: 'eventual', name: 'SimpleJob') }
+      let(:p30_payload) { default_payload.merge(priority: 'reporting', name: 'SimpleJob') }
       let!(:p0_workable_job) { Delayed::Job.create! p0_attributes.merge(run_at: now - 30.seconds) }
       let!(:p0_failed_job) { Delayed::Job.create! p0_attributes.merge(failed_attributes) }
       let!(:p0_future_job) { Delayed::Job.create! p0_attributes.merge(run_at: now + 1.hour) }
@@ -212,45 +201,43 @@ RSpec.describe Delayed::Monitor do
           .and emit_notification("delayed.job.max_age").with_payload(p30_payload.merge(queue: 'banana')).approximately.with_value(4.hours)
       end
 
-      it 'emits max_age_by_name grouped by job name' do
-        expect { subject.run! }
-          .to emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'SimpleJob')).approximately.with_value(30.seconds)
-          .and emit_notification("delayed.job.max_age_by_name").with_payload(p10_payload.merge(name: 'SimpleJob')).approximately.with_value(2.minutes)
-          .and emit_notification("delayed.job.max_age_by_name").with_payload(p20_payload.merge(name: 'SimpleJob')).approximately.with_value(1.hour)
-          .and emit_notification("delayed.job.max_age_by_name").with_payload(p30_payload.merge(name: 'SimpleJob')).approximately.with_value(6.hours)
-          .and emit_notification("delayed.job.max_age_by_name").with_payload(p30_payload.merge(queue: 'banana', name: 'SimpleJob')).approximately.with_value(4.hours)
-      end
-
       context 'when multiple job names share a priority and queue' do
         let!(:other_named_job) { Delayed::Job.create! p0_attributes.merge(name: 'OtherJob', run_at: now - 10.minutes) }
 
-        it 'emits a separate max_age_by_name series per name' do
+        it 'emits a separate series per name' do
           expect { subject.run! }
-            .to emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'SimpleJob')).approximately.with_value(30.seconds)
-            .and emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'OtherJob')).approximately.with_value(10.minutes)
+            .to emit_notification("delayed.job.max_age").with_payload(p0_payload).approximately.with_value(30.seconds)
+            .and emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(name: 'OtherJob')).approximately.with_value(10.minutes)
         end
       end
 
-      context 'when metrics_by_attribute is empty' do
+      context 'when tag_columns is empty' do
         around do |example|
-          described_class.metrics_by_attribute = {}
+          described_class.tag_columns = []
           example.run
         ensure
-          described_class.metrics_by_attribute = { max_age: %i(name) }
+          described_class.tag_columns = %i(name)
         end
 
-        it 'does not emit max_age_by_name' do
-          expect(emitted_event_names("delayed.job.max_age_by_name") { subject.run! }).to be_empty
+        it 'emits metrics without name tags' do
+          expect { subject.run! }
+            .to emit_notification("delayed.job.max_age").with_payload(p0_payload.except(:name)).approximately.with_value(30.seconds)
         end
       end
 
       context 'when the delayed_jobs table has no name column' do
         before do
+          described_class.instance_variable_set(:@tag_columns, nil)
           allow(Delayed::Job).to receive(:column_names).and_return(Delayed::Job.column_names - ['name'])
         end
 
-        it 'does not emit max_age_by_name' do
-          expect(emitted_event_names("delayed.job.max_age_by_name") { subject.run! }).to be_empty
+        after do
+          described_class.instance_variable_set(:@tag_columns, nil)
+        end
+
+        it 'defaults to emitting metrics without name tags' do
+          expect { subject.run! }
+            .to emit_notification("delayed.job.max_age").with_payload(p0_payload.except(:name)).approximately.with_value(30.seconds)
         end
       end
 
@@ -267,20 +254,20 @@ RSpec.describe Delayed::Monitor do
 
         let!(:unnamed_job) { Delayed::Job.create! p0_attributes.merge(name: nil, run_at: now - 10.minutes) }
 
-        it "emits max_age_by_name under the name 'unknown'" do
+        it "emits metrics under the name 'unset'" do
           expect { subject.run! }
-            .to emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'unknown')).approximately.with_value(10.minutes)
+            .to emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(name: 'unset')).approximately.with_value(10.minutes)
         end
       end
 
-      context 'when metrics_by_attribute pairs metrics with a custom column' do
+      context 'when tag_columns includes a custom column' do
         around do |example|
           Delayed::Job.connection.add_column :delayed_jobs, :owner, :string
           Delayed::Job.reset_column_information
-          described_class.metrics_by_attribute = { max_age: %i(name owner), failed_count: %i(owner) }
+          described_class.tag_columns = %i(name owner)
           example.run
         ensure
-          described_class.metrics_by_attribute = { max_age: %i(name) }
+          described_class.tag_columns = %i(name)
           Delayed::Job.connection.remove_column :delayed_jobs, :owner
           Delayed::Job.reset_column_information
         end
@@ -288,36 +275,19 @@ RSpec.describe Delayed::Monitor do
         let!(:team_a_job) { Delayed::Job.create! p0_attributes.merge(owner: 'team_a', run_at: now - 10.minutes) }
         let!(:team_b_job) { Delayed::Job.create! p0_attributes.merge(owner: 'team_b', run_at: now - 20.minutes) }
 
-        it "emits a max_age_by_owner series per owner, reporting ownerless rows as 'unknown'" do
+        it "tags each series with the column's value, reporting NULLs as 'unset'" do
           expect { subject.run! }
-            .to emit_notification("delayed.job.max_age_by_owner").with_payload(p0_payload.merge(owner: 'team_a')).approximately.with_value(10.minutes)
-            .and emit_notification("delayed.job.max_age_by_owner").with_payload(p0_payload.merge(owner: 'team_b')).approximately.with_value(20.minutes)
-            .and emit_notification("delayed.job.max_age_by_owner").with_payload(p0_payload.merge(owner: 'unknown')).approximately.with_value(30.seconds)
-        end
-
-        it 'emits other paired metrics by the same column' do
-          expect { subject.run! }
-            .to emit_notification("delayed.job.failed_count_by_owner").with_payload(p0_payload.merge(owner: 'unknown')).with_value(1)
-        end
-
-        it 'emits max_age_by_name independently, without owner tags' do
-          expect { subject.run! }
-            .to emit_notification("delayed.job.max_age_by_name").with_payload(p0_payload.merge(name: 'SimpleJob')).approximately.with_value(20.minutes)
+            .to emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(owner: 'team_a')).approximately.with_value(10.minutes)
+            .and emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(owner: 'team_b')).approximately.with_value(20.minutes)
+            .and emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(owner: 'unset')).approximately.with_value(30.seconds)
+            .and emit_notification("delayed.job.failed_count").with_payload(p0_payload.merge(owner: 'unset')).with_value(1)
         end
       end
 
-      context 'when metrics_by_attribute names a column that does not exist' do
-        around do |example|
-          described_class.metrics_by_attribute = { max_age: %i(name owner) }
-          example.run
-        ensure
-          described_class.metrics_by_attribute = { max_age: %i(name) }
-        end
-
-        it 'skips the missing column but still emits max_age_by_name' do
-          events = emitted_event_names(/delayed\.job\.max_age_by_/) { subject.run! }
-          expect(events).to include("delayed.job.max_age_by_name")
-          expect(events).not_to include("delayed.job.max_age_by_owner")
+      context 'when tag_columns names a column that does not exist' do
+        it 'raises loudly rather than skipping the column' do
+          expect { described_class.tag_columns = %i(name owner) }
+            .to raise_error(ArgumentError, /tag_columns includes columns missing from delayed_jobs\. Available columns: .*\bname\b/)
         end
       end
 
@@ -328,8 +298,8 @@ RSpec.describe Delayed::Monitor do
         ensure
           Delayed::Priority.names = nil
         end
-        let(:p0_payload) { default_payload.merge(priority: 'high') }
-        let(:p20_payload) { default_payload.merge(priority: 'low') }
+        let(:p0_payload) { default_payload.merge(priority: 'high', name: 'SimpleJob') }
+        let(:p20_payload) { default_payload.merge(priority: 'low', name: 'SimpleJob') }
 
         it 'emits the expected results for each metric' do
           expect { subject.run! }
@@ -343,7 +313,7 @@ RSpec.describe Delayed::Monitor do
             .and emit_notification("delayed.job.workable_count").with_payload(p0_payload).with_value(2)
             .and emit_notification("delayed.job.max_age").with_payload(p0_payload).approximately.with_value(2.minutes)
             .and emit_notification("delayed.job.max_lock_age").with_payload(p0_payload).approximately.with_value(7.minutes)
-            .and emit_notification("delayed.job.alert_age_percent").with_payload(p0_payload).approximately.with_value(0)
+            .and emit_notification("delayed.job.alert_age_percent").with_payload(p0_payload.except(:name)).approximately.with_value(0)
             .and emit_notification("delayed.job.count").with_payload(p20_payload).with_value(8)
             .and emit_notification("delayed.job.future_count").with_payload(p20_payload).with_value(2)
             .and emit_notification("delayed.job.locked_count").with_payload(p20_payload).with_value(2)
@@ -353,7 +323,7 @@ RSpec.describe Delayed::Monitor do
             .and emit_notification("delayed.job.workable_count").with_payload(p20_payload).with_value(2)
             .and emit_notification("delayed.job.max_age").with_payload(p20_payload).approximately.with_value(6.hours)
             .and emit_notification("delayed.job.max_lock_age").with_payload(p20_payload).approximately.with_value(11.minutes)
-            .and emit_notification("delayed.job.alert_age_percent").with_payload(p20_payload).approximately.with_value(0)
+            .and emit_notification("delayed.job.alert_age_percent").with_payload(p20_payload.except(:name)).approximately.with_value(0)
             .and emit_notification("delayed.job.workable_count").with_payload(p20_payload.merge(queue: 'banana')).with_value(1)
             .and emit_notification("delayed.job.max_age").with_payload(p20_payload.merge(queue: 'banana')).approximately.with_value(4.hours)
         end
@@ -384,7 +354,7 @@ RSpec.describe Delayed::Monitor do
           Delayed::Priority.names = nil
           Delayed::Worker.queues = []
         end
-        let(:banana_payload) { default_payload.merge(queue: 'banana', priority: 'interactive') }
+        let(:banana_payload) { default_payload.merge(queue: 'banana', priority: 'interactive', name: 'SimpleJob') }
         let(:gram_payload) { default_payload.merge(queue: 'gram', priority: 'interactive') }
 
         it 'emits the expected results for each queue' do
@@ -394,7 +364,7 @@ RSpec.describe Delayed::Monitor do
             .and emit_notification("delayed.job.future_count").with_payload(banana_payload).with_value(0)
             .and emit_notification("delayed.job.locked_count").with_payload(banana_payload).with_value(0)
             .and emit_notification("delayed.job.erroring_count").with_payload(banana_payload).with_value(0)
-            .and emit_notification("delayed.job.failed_count").with_payload(banana_payload).with_value(0)
+            .and emit_notification("delayed.job.failed_count").with_payload(banana_payload.except(:name)).with_value(0)
             .and emit_notification("delayed.job.working_count").with_payload(banana_payload).with_value(0)
             .and emit_notification("delayed.job.workable_count").with_payload(banana_payload).with_value(1)
             .and emit_notification("delayed.job.max_age").with_payload(banana_payload).approximately.with_value(4.hours)
@@ -466,7 +436,7 @@ RSpec.describe Delayed::Monitor do
     end
 
     context 'when a job is locked (in-flight)' do
-      let(:payload) { default_payload.merge(priority: 'interactive') }
+      let(:payload) { default_payload.merge(priority: 'interactive', name: 'SimpleJob') }
       let(:base_attributes) do
         {
           priority: 0,
@@ -489,11 +459,6 @@ RSpec.describe Delayed::Monitor do
           .and emit_notification("delayed.job.alert_age_percent").with_payload(payload).approximately.with_value(0)
       end
 
-      it 'excludes the locked job from max_age_by_name' do
-        expect { subject.run! }
-          .to emit_notification("delayed.job.max_age_by_name").with_payload(payload.merge(name: 'SimpleJob')).approximately.with_value(0)
-      end
-
       context 'and a workable job is also present in the same group' do
         # The workable job's run_at is newer than the locked job's, so max_age must
         # track the workable job (30s), not the locked job (1 hour).
@@ -506,13 +471,6 @@ RSpec.describe Delayed::Monitor do
             .and emit_notification("delayed.job.max_age").with_payload(payload).approximately.with_value(30.seconds)
         end
       end
-    end
-  end
-
-  describe '.metrics_by_attribute=' do
-    it 'rejects unknown metrics at assignment time' do
-      expect { described_class.metrics_by_attribute = { min_age: %i(name) } }
-        .to raise_error(ArgumentError, /Unknown metrics in metrics_by_attribute: min_age/)
     end
   end
 
@@ -537,11 +495,10 @@ RSpec.describe Delayed::Monitor do
     end
 
     def query_descriptions
-      (described_class::METRICS + %w(max_age_by_name)).each do |metric|
+      described_class::METRICS.each do |metric|
         queries << "-- QUERIES FOR `#{metric}`:"
         queries << "---------------------------------"
-        base, attribute = metric.split('_by_')
-        monitor.query_for(base, *[attribute&.to_sym].compact)
+        monitor.query_for(metric)
         queries << "-- (no new queries)" unless queries.last == '---'
       end
       queries.dup.map { |query| query.try(:full_description) || query }

--- a/spec/delayed/monitor_spec.rb
+++ b/spec/delayed/monitor_spec.rb
@@ -279,8 +279,15 @@ RSpec.describe Delayed::Monitor do
       end
 
       context 'when tag_columns names a column that does not exist' do
-        it 'raises loudly rather than skipping the column' do
-          expect { described_class.tag_columns = %i(name owner) }
+        around do |example|
+          described_class.tag_columns = %i(name missing_column)
+          example.run
+        ensure
+          described_class.tag_columns = []
+        end
+
+        it 'raises loudly at monitor startup rather than skipping the column' do
+          expect { described_class.new }
             .to raise_error(ArgumentError, /tag_columns includes columns missing from delayed_jobs\. Available columns: .*\bname\b/)
         end
       end

--- a/spec/delayed/monitor_spec.rb
+++ b/spec/delayed/monitor_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe Delayed::Monitor do
     }
   end
 
+  describe '.tag_columns' do
+    it 'defaults to no tag columns' do
+      expect(described_class.tag_columns).to eq []
+    end
+  end
+
   describe '#run!' do
     let(:app_local_db_time) { false }
 
@@ -132,10 +138,10 @@ RSpec.describe Delayed::Monitor do
       let(:p10_attributes) { job_attributes.merge(priority: 13, locked_at: now - 1.day) }
       let(:p20_attributes) { job_attributes.merge(priority: 23, attempts: 1) }
       let(:p30_attributes) { job_attributes.merge(priority: 999, locked_at: now - 1.day) }
-      let(:p0_payload) { default_payload.merge(priority: 'interactive', name: 'SimpleJob') }
-      let(:p10_payload) { default_payload.merge(priority: 'user_visible', name: 'SimpleJob') }
-      let(:p20_payload) { default_payload.merge(priority: 'eventual', name: 'SimpleJob') }
-      let(:p30_payload) { default_payload.merge(priority: 'reporting', name: 'SimpleJob') }
+      let(:p0_payload) { default_payload.merge(priority: 'interactive') }
+      let(:p10_payload) { default_payload.merge(priority: 'user_visible') }
+      let(:p20_payload) { default_payload.merge(priority: 'eventual') }
+      let(:p30_payload) { default_payload.merge(priority: 'reporting') }
       let!(:p0_workable_job) { Delayed::Job.create! p0_attributes.merge(run_at: now - 30.seconds) }
       let!(:p0_failed_job) { Delayed::Job.create! p0_attributes.merge(failed_attributes) }
       let!(:p0_future_job) { Delayed::Job.create! p0_attributes.merge(run_at: now + 1.hour) }
@@ -201,62 +207,49 @@ RSpec.describe Delayed::Monitor do
           .and emit_notification("delayed.job.max_age").with_payload(p30_payload.merge(queue: 'banana')).approximately.with_value(4.hours)
       end
 
-      context 'when multiple job names share a priority and queue' do
-        let!(:other_named_job) { Delayed::Job.create! p0_attributes.merge(name: 'OtherJob', run_at: now - 10.minutes) }
-
-        it 'emits a separate series per name' do
-          expect { subject.run! }
-            .to emit_notification("delayed.job.max_age").with_payload(p0_payload).approximately.with_value(30.seconds)
-            .and emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(name: 'OtherJob')).approximately.with_value(10.minutes)
-        end
-      end
-
-      context 'when tag_columns is empty' do
+      context 'when tag_columns is set to name' do
         around do |example|
-          described_class.tag_columns = []
-          example.run
-        ensure
           described_class.tag_columns = %i(name)
-        end
-
-        it 'emits metrics without name tags' do
-          expect { subject.run! }
-            .to emit_notification("delayed.job.max_age").with_payload(p0_payload.except(:name)).approximately.with_value(30.seconds)
-        end
-      end
-
-      context 'when the delayed_jobs table has no name column' do
-        before do
-          described_class.instance_variable_set(:@tag_columns, nil)
-          allow(Delayed::Job).to receive(:column_names).and_return(Delayed::Job.column_names - ['name'])
-        end
-
-        after do
-          described_class.instance_variable_set(:@tag_columns, nil)
-        end
-
-        it 'defaults to emitting metrics without name tags' do
-          expect { subject.run! }
-            .to emit_notification("delayed.job.max_age").with_payload(p0_payload.except(:name)).approximately.with_value(30.seconds)
-        end
-      end
-
-      context 'when a job predates the name column' do
-        around do |example|
-          ValidateRunAtAndNameNotNull.migrate(:down)
-          AddRunAtAndNameNotNullCheck.migrate(:down)
           example.run
         ensure
-          Delayed::Job.delete_all
-          AddRunAtAndNameNotNullCheck.migrate(:up)
-          ValidateRunAtAndNameNotNull.migrate(:up)
+          described_class.tag_columns = []
         end
 
-        let!(:unnamed_job) { Delayed::Job.create! p0_attributes.merge(name: nil, run_at: now - 10.minutes) }
+        let(:named_payload) { p0_payload.merge(name: 'SimpleJob') }
 
-        it "emits metrics under the name 'unset'" do
+        it 'tags each series with the job name' do
           expect { subject.run! }
-            .to emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(name: 'unset')).approximately.with_value(10.minutes)
+            .to emit_notification("delayed.job.max_age").with_payload(named_payload).approximately.with_value(30.seconds)
+            .and emit_notification("delayed.job.failed_count").with_payload(named_payload).with_value(1)
+        end
+
+        context 'when multiple job names share a priority and queue' do
+          let!(:other_named_job) { Delayed::Job.create! p0_attributes.merge(name: 'OtherJob', run_at: now - 10.minutes) }
+
+          it 'emits a separate series per name' do
+            expect { subject.run! }
+              .to emit_notification("delayed.job.max_age").with_payload(named_payload).approximately.with_value(30.seconds)
+              .and emit_notification("delayed.job.max_age").with_payload(named_payload.merge(name: 'OtherJob')).approximately.with_value(10.minutes)
+          end
+        end
+
+        context 'when a job predates the name column' do
+          around do |example|
+            ValidateRunAtAndNameNotNull.migrate(:down)
+            AddRunAtAndNameNotNullCheck.migrate(:down)
+            example.run
+          ensure
+            Delayed::Job.delete_all
+            AddRunAtAndNameNotNullCheck.migrate(:up)
+            ValidateRunAtAndNameNotNull.migrate(:up)
+          end
+
+          let!(:unnamed_job) { Delayed::Job.create! p0_attributes.merge(name: nil, run_at: now - 10.minutes) }
+
+          it "emits metrics under the name 'unset'" do
+            expect { subject.run! }
+              .to emit_notification("delayed.job.max_age").with_payload(named_payload.merge(name: 'unset')).approximately.with_value(10.minutes)
+          end
         end
       end
 
@@ -267,20 +260,21 @@ RSpec.describe Delayed::Monitor do
           described_class.tag_columns = %i(name owner)
           example.run
         ensure
-          described_class.tag_columns = %i(name)
+          described_class.tag_columns = []
           Delayed::Job.connection.remove_column :delayed_jobs, :owner
           Delayed::Job.reset_column_information
         end
 
+        let(:named_payload) { p0_payload.merge(name: 'SimpleJob') }
         let!(:team_a_job) { Delayed::Job.create! p0_attributes.merge(owner: 'team_a', run_at: now - 10.minutes) }
         let!(:team_b_job) { Delayed::Job.create! p0_attributes.merge(owner: 'team_b', run_at: now - 20.minutes) }
 
         it "tags each series with the column's value, reporting NULLs as 'unset'" do
           expect { subject.run! }
-            .to emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(owner: 'team_a')).approximately.with_value(10.minutes)
-            .and emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(owner: 'team_b')).approximately.with_value(20.minutes)
-            .and emit_notification("delayed.job.max_age").with_payload(p0_payload.merge(owner: 'unset')).approximately.with_value(30.seconds)
-            .and emit_notification("delayed.job.failed_count").with_payload(p0_payload.merge(owner: 'unset')).with_value(1)
+            .to emit_notification("delayed.job.max_age").with_payload(named_payload.merge(owner: 'team_a')).approximately.with_value(10.minutes)
+            .and emit_notification("delayed.job.max_age").with_payload(named_payload.merge(owner: 'team_b')).approximately.with_value(20.minutes)
+            .and emit_notification("delayed.job.max_age").with_payload(named_payload.merge(owner: 'unset')).approximately.with_value(30.seconds)
+            .and emit_notification("delayed.job.failed_count").with_payload(named_payload.merge(owner: 'unset')).with_value(1)
         end
       end
 
@@ -298,8 +292,8 @@ RSpec.describe Delayed::Monitor do
         ensure
           Delayed::Priority.names = nil
         end
-        let(:p0_payload) { default_payload.merge(priority: 'high', name: 'SimpleJob') }
-        let(:p20_payload) { default_payload.merge(priority: 'low', name: 'SimpleJob') }
+        let(:p0_payload) { default_payload.merge(priority: 'high') }
+        let(:p20_payload) { default_payload.merge(priority: 'low') }
 
         it 'emits the expected results for each metric' do
           expect { subject.run! }
@@ -313,7 +307,7 @@ RSpec.describe Delayed::Monitor do
             .and emit_notification("delayed.job.workable_count").with_payload(p0_payload).with_value(2)
             .and emit_notification("delayed.job.max_age").with_payload(p0_payload).approximately.with_value(2.minutes)
             .and emit_notification("delayed.job.max_lock_age").with_payload(p0_payload).approximately.with_value(7.minutes)
-            .and emit_notification("delayed.job.alert_age_percent").with_payload(p0_payload.except(:name)).approximately.with_value(0)
+            .and emit_notification("delayed.job.alert_age_percent").with_payload(p0_payload).approximately.with_value(0)
             .and emit_notification("delayed.job.count").with_payload(p20_payload).with_value(8)
             .and emit_notification("delayed.job.future_count").with_payload(p20_payload).with_value(2)
             .and emit_notification("delayed.job.locked_count").with_payload(p20_payload).with_value(2)
@@ -323,7 +317,7 @@ RSpec.describe Delayed::Monitor do
             .and emit_notification("delayed.job.workable_count").with_payload(p20_payload).with_value(2)
             .and emit_notification("delayed.job.max_age").with_payload(p20_payload).approximately.with_value(6.hours)
             .and emit_notification("delayed.job.max_lock_age").with_payload(p20_payload).approximately.with_value(11.minutes)
-            .and emit_notification("delayed.job.alert_age_percent").with_payload(p20_payload.except(:name)).approximately.with_value(0)
+            .and emit_notification("delayed.job.alert_age_percent").with_payload(p20_payload).approximately.with_value(0)
             .and emit_notification("delayed.job.workable_count").with_payload(p20_payload.merge(queue: 'banana')).with_value(1)
             .and emit_notification("delayed.job.max_age").with_payload(p20_payload.merge(queue: 'banana')).approximately.with_value(4.hours)
         end
@@ -354,7 +348,7 @@ RSpec.describe Delayed::Monitor do
           Delayed::Priority.names = nil
           Delayed::Worker.queues = []
         end
-        let(:banana_payload) { default_payload.merge(queue: 'banana', priority: 'interactive', name: 'SimpleJob') }
+        let(:banana_payload) { default_payload.merge(queue: 'banana', priority: 'interactive') }
         let(:gram_payload) { default_payload.merge(queue: 'gram', priority: 'interactive') }
 
         it 'emits the expected results for each queue' do
@@ -364,7 +358,7 @@ RSpec.describe Delayed::Monitor do
             .and emit_notification("delayed.job.future_count").with_payload(banana_payload).with_value(0)
             .and emit_notification("delayed.job.locked_count").with_payload(banana_payload).with_value(0)
             .and emit_notification("delayed.job.erroring_count").with_payload(banana_payload).with_value(0)
-            .and emit_notification("delayed.job.failed_count").with_payload(banana_payload.except(:name)).with_value(0)
+            .and emit_notification("delayed.job.failed_count").with_payload(banana_payload).with_value(0)
             .and emit_notification("delayed.job.working_count").with_payload(banana_payload).with_value(0)
             .and emit_notification("delayed.job.workable_count").with_payload(banana_payload).with_value(1)
             .and emit_notification("delayed.job.max_age").with_payload(banana_payload).approximately.with_value(4.hours)
@@ -436,7 +430,7 @@ RSpec.describe Delayed::Monitor do
     end
 
     context 'when a job is locked (in-flight)' do
-      let(:payload) { default_payload.merge(priority: 'interactive', name: 'SimpleJob') }
+      let(:payload) { default_payload.merge(priority: 'interactive') }
       let(:base_attributes) do
         {
           priority: 0,

--- a/spec/delayed/monitor_spec.rb
+++ b/spec/delayed/monitor_spec.rb
@@ -246,9 +246,9 @@ RSpec.describe Delayed::Monitor do
 
           let!(:unnamed_job) { Delayed::Job.create! p0_attributes.merge(name: nil, run_at: now - 10.minutes) }
 
-          it "emits metrics under the name 'unset'" do
+          it 'emits metrics with a nil name' do
             expect { subject.run! }
-              .to emit_notification("delayed.job.max_age").with_payload(named_payload.merge(name: 'unset')).approximately.with_value(10.minutes)
+              .to emit_notification("delayed.job.max_age").with_payload(named_payload.merge(name: nil)).approximately.with_value(10.minutes)
           end
         end
       end
@@ -269,12 +269,12 @@ RSpec.describe Delayed::Monitor do
         let!(:team_a_job) { Delayed::Job.create! p0_attributes.merge(owner: 'team_a', run_at: now - 10.minutes) }
         let!(:team_b_job) { Delayed::Job.create! p0_attributes.merge(owner: 'team_b', run_at: now - 20.minutes) }
 
-        it "tags each series with the column's value, reporting NULLs as 'unset'" do
+        it "tags each series with the column's value, passing NULLs through as nil" do
           expect { subject.run! }
             .to emit_notification("delayed.job.max_age").with_payload(named_payload.merge(owner: 'team_a')).approximately.with_value(10.minutes)
             .and emit_notification("delayed.job.max_age").with_payload(named_payload.merge(owner: 'team_b')).approximately.with_value(20.minutes)
-            .and emit_notification("delayed.job.max_age").with_payload(named_payload.merge(owner: 'unset')).approximately.with_value(30.seconds)
-            .and emit_notification("delayed.job.failed_count").with_payload(named_payload.merge(owner: 'unset')).with_value(1)
+            .and emit_notification("delayed.job.max_age").with_payload(named_payload.merge(owner: nil)).approximately.with_value(30.seconds)
+            .and emit_notification("delayed.job.failed_count").with_payload(named_payload.merge(owner: nil)).with_value(1)
         end
       end
 


### PR DESCRIPTION
**What**

All `delayed.job.*` monitor metrics can now be grouped by — and tagged with — a configurable set of job columns, in addition to `priority` and `queue`. This is opt-in: `Delayed::Monitor.tag_columns` defaults to `[]`, and with the default the emitted payloads are identical to before.

Any column on the jobs table can be tagged, including custom columns an application adds (`table`/`database`/`database_adapter` tags elided below):

```ruby
# example with jobs table having the `name` column
Delayed::Monitor.tag_columns = %i(name)

# delayed.job.count emits one series per (priority, queue, name), plus an
# untagged zero baseline per (priority, queue) — here, one enqueued job:
{ priority: 'interactive',  queue: 'default', name: 'SimpleJob', value: 1 }
{ priority: 'interactive',  queue: 'default', value: 0 }
{ priority: 'user_visible', queue: 'default', value: 0 }
{ priority: 'eventual',     queue: 'default', value: 0 }
{ priority: 'reporting',    queue: 'default', value: 0 }
```

```ruby
# example with jobs table having both `name` and `owner` columns
Delayed::Monitor.tag_columns = %i(name owner)

# both columns land in the same GROUP BY, so each series carries both tags —
# one series per (priority, queue, name, owner). Here: 4 interactive SimpleJob
# jobs with no owner, plus one owned by team_a and one by team_b.
{ priority: 'interactive',  queue: 'default', name: 'SimpleJob', owner: 'unset',  value: 4 }
{ priority: 'interactive',  queue: 'default', name: 'SimpleJob', owner: 'team_a', value: 1 }
{ priority: 'interactive',  queue: 'default', name: 'SimpleJob', owner: 'team_b', value: 1 }
{ priority: 'interactive',  queue: 'default', value: 0 }
{ priority: 'user_visible', queue: 'default', value: 0 }
{ priority: 'eventual',     queue: 'default', value: 0 }
{ priority: 'reporting',    queue: 'default', value: 0 }
```

**Why**

When `delayed.job.max_age` alerts, a common first question is "which job is stuck?" (and often "whose is it?"). Previously that required querying the database by hand. Now it's a `max by {queue, priority, name}` away in the metrics provider when `tag_columns` is configured with `:name`. Since similar questions can arise from other custom columns, `tag_columns` can be configured for multiple columns.

**How**

- `grouped_query` accepts `extra_group_columns`, threaded into both the inner and outer `GROUP BY`s, so the query *count* is unchanged — still one query each for `live`/`pending`/`failed` per run. The query *cost* is not. No existing index contains a tag column (`idx_delayed_jobs_live` is `(priority, run_at, locked_at, queue, attempts)` partial on `failed_at IS NULL`; `idx_delayed_jobs_failed` is `(priority, queue)`), so tagging costs the monitor its covering-index reads and adds a sort. The plan snapshots taken while `%i(name)` was still the default (34c6105) measure this against `main`:
  - **postgres:** the index-only scans behind `count` (both the live and failed halves) become plain index scans — a heap fetch per matching row — each with an added sort
  - **mysql:** the failed-jobs query drops from a covering index range scan to a full table scan; the live and pending queries lose covering-index lookups
  - **sqlite:** same index scans, plus a temp B-tree for the failed query's inner `GROUP BY`
  These run every `sleep_delay` (60s by default), and plan choices shift with table size, so check the plans against a production-sized jobs table before enabling a tag column. Documented in the README.
- `Delayed::Monitor.tag_columns=` validates columns against the schema and raises `ArgumentError` at assignment (i.e. at boot when set in an initializer) rather than failing later in the monitor run loop
  **->-> Note this means setting it in an initializer requires a DB connection at boot <-<-**
- `NULL` tag values are reported as `'unset'` (e.g. jobs enqueued before the column existed)

**Behavioral notes / compatibility**

- No new event names, and no removed ones
  - Existing subscribers keep working, and with the default `[]` the payloads and query shapes are unchanged
  - Once configured, a metric's cardinality is multiplicative across tag columns (priority × queue × name × owner) and scales with the number of distinct values; untagged zero baselines are still emitted for every (`priority`, configured `queue`) regardless of whether tagged series exist
  - Dashboards aggregating these gauges should `sum by` / `max by` accordingly
- The `README.md` documents the behavior, the cardinality and index tradeoffs, and a three-deploy rollout guide for adding a custom tag column. It also now documents `delayed.job.locked_count`, which was previously undocumented.

**Testing**

- Full suite passes, with new coverage for: multiple names per (`priority`, `queue`), `'unset'` reporting, custom columns, and assignment-time validation. The pre-existing examples continue to cover the empty-`tag_columns` default.
- SQL/query-plan snapshots are **unchanged** across sqlite/mysql/postgres, confirming the default configuration emits the same queries as before. Note that this leaves no pinned plan for the tagged `GROUP BY` — the tagged plans quoted above live only in this PR's history (34c6105), since the `describe 'SQL'` block reverted to the untagged default in a0dba18.

**Other notes**

Initially, the idea was to just add the ability to tag _ONLY_ by name. This is captured in the first commit. Then the thinking evolved to enable fully customizable (metric, tag column) configurations. This was rejected as it makes more sense to have each tag column emitted across all metrics which exist instead as it seemed unlikely we would want to configure `max_age_by_name` and not, for example, `failed_count_by_name`. The final commit is where this effort landed so that each tagged column is emitted against each metric instead. Noting this evolution in case it (notably the second commit) helps highlight future capabilities that might be desired.
