### PR TITLE
fix(enqueue_all): support timestamp overrides

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -76,7 +76,10 @@ module Delayed
 
         def bulk_insert_all(jobs)
           now = db_time_now
-          jobs.each { |job| job.created_at = job.updated_at = now }
+          jobs.each do |job|
+            job.created_at ||= now
+            job.updated_at ||= now
+          end
           rows = jobs.map { |job| job.attributes.compact }
           result = insert_all(rows) # rubocop:disable Rails/SkipsModelValidations
           return unless connection_pool.with_connection(&:supports_insert_returning?)

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -290,6 +290,26 @@ describe Delayed::Job do
         expect { described_class.enqueue_all(jobs) }.to raise_error(RuntimeError, /Delayed::Job enqueue methods do not accept ActiveJobs/)
       end
     end
+
+    it 'stamps created_at and updated_at' do
+      now = described_class.db_time_now
+      described_class.enqueue_all([build_job])
+
+      described_class.last.tap do |job|
+        expect(job.created_at).to be_within(1).of(now)
+        expect(job.updated_at).to be_within(1).of(now)
+      end
+    end
+
+    it 'preserves a pre-assigned created_at while still stamping updated_at' do
+      original_time = described_class.db_time_now - 3.hours
+      described_class.enqueue_all([build_job(SimpleJob.new, created_at: original_time)])
+
+      described_class.last.tap do |job|
+        expect(job.created_at).to be_within(1).of(original_time)
+        expect(job.updated_at).to be_within(1).of(described_class.db_time_now)
+      end
+    end
   end
 
   describe '#hook' do


### PR DESCRIPTION
Previously, `bulk_insert_all`/`enqueue_all` unconditionally overwrote created_at/updated_at on every job, so a caller (or an upstream preparer, e.g. `ActiveJob`'s `retry_on` job builder) could never supply its own creation time (e.g. using created_at to preserve an "enqueued_at" value across retries).

Insert-time stamping now only fills in timestamps that are `nil`, matching ActiveRecord's own timestamp semantics.

Behavior is unchanged for jobs that don't pre-assign anything.
