### PR TITLE
feat(ActiveJob): honor scheduled_at as the default run_at

### DIFF
--- a/lib/delayed/backend/job_preparer.rb
+++ b/lib/delayed/backend/job_preparer.rb
@@ -37,6 +37,7 @@ module Delayed
       end
 
       def set_run_at
+        options[:run_at] ||= options[:payload_object].scheduled_at if options[:payload_object].respond_to?(:scheduled_at)
         options[:run_at] ||= Job.db_time_now
       end
 

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -199,6 +199,21 @@ describe Delayed::Job do
       end
     end
 
+    context 'when payload is an ActiveJob wrapper built from previously-serialized job data' do
+      let(:arbitrary_time) { Time.parse('2021-01-05 03:34:33 UTC') }
+
+      if ActiveJob.gem_version.release >= Gem::Version.new('7.1')
+        it "preserves the wrapped job's scheduled_at as run_at" do
+          active_job = ActiveJobJob.new
+          active_job.scheduled_at = arbitrary_time + 1.hour
+
+          job = described_class.enqueue(Delayed::JobWrapper.new(active_job.serialize))
+
+          expect(job.run_at).to eq(arbitrary_time + 1.hour)
+        end
+      end
+    end
+
     context 'when payload is a bare ActiveJob::Base instance' do
       it 'raises' do
         expect { described_class.enqueue(payload_object: ActiveJobJob.new) }.to raise_error(RuntimeError, /Delayed::Job enqueue methods do not accept ActiveJobs/)


### PR DESCRIPTION
When a JobWrapper is built from previously-serialized job data (e.g. via `retry_on` or `retry_job`), the wrapped job's scheduled_at was ignored and the job would run immediately.

The preparer now falls back to the payload's scheduled_at before defaulting to now.

(This only applies to ActiveJobs, and an explicit :run_at option still wins.)
