### PR TITLE
feat(ActiveJob): preserve enqueued_at as created_at

### DIFF
--- a/lib/delayed/backend/job_preparer.rb
+++ b/lib/delayed/backend/job_preparer.rb
@@ -13,6 +13,7 @@ module Delayed
         set_queue_name
         set_priority
         set_run_at
+        set_created_at
         set_name
         handle_dst
         reject_stale_run_at
@@ -39,6 +40,10 @@ module Delayed
       def set_run_at
         options[:run_at] ||= options[:payload_object].scheduled_at if options[:payload_object].respond_to?(:scheduled_at)
         options[:run_at] ||= Job.db_time_now
+      end
+
+      def set_created_at
+        options[:created_at] ||= options[:payload_object].enqueued_at if options[:payload_object].respond_to?(:enqueued_at)
       end
 
       def set_name

--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -543,6 +543,20 @@ RSpec.describe Delayed::ActiveJobAdapter do
       expect(Delayed::Job.last.last_error).to start_with('RetryTestError')
     end
 
+    it 'preserves the original creation time on the re-enqueued job' do
+      Timecop.freeze(arbitrary_time) do
+        MyRetryJob.perform_later('RetryTestError')
+      end
+
+      Timecop.freeze(arbitrary_time + 2.hours) do
+        expect(Delayed::Worker.new.work_off).to eq([1, 0])
+      end
+
+      retried = Delayed::Job.last
+      expect(retried.created_at).to eq(arbitrary_time)
+      expect(retried.run_at).to be_within(1.second).of(arbitrary_time + 2.hours + 3.seconds)
+    end
+
     context 'when attempts are exhausted' do
       it 're-raises the error, leaving the job to be retried by the worker itself' do
         job = MyRetryJob.new('RetryTestError')

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -202,6 +202,14 @@ describe Delayed::Job do
     context 'when payload is an ActiveJob wrapper built from previously-serialized job data' do
       let(:arbitrary_time) { Time.parse('2021-01-05 03:34:33 UTC') }
 
+      it "preserves the wrapped job's enqueued_at as created_at" do
+        job_data = Timecop.freeze(arbitrary_time) { ActiveJobJob.new.serialize }
+
+        job = described_class.enqueue(Delayed::JobWrapper.new(job_data))
+
+        expect(job.reload.created_at).to eq(arbitrary_time)
+      end
+
       if ActiveJob.gem_version.release >= Gem::Version.new('7.1')
         it "preserves the wrapped job's scheduled_at as run_at" do
           active_job = ActiveJobJob.new


### PR DESCRIPTION
When a job is re-enqueued from previously-serialized job data (most notably a `retry_on`) the new row's created_at was stamped at insert time, so each retry reset the job's apparent age.

This change defaults a row's `created_at` to the wrapped job's (ActiveJob-maintained) enqueued_at, keeping the original creation time across the retry chain.

Notably, `created_at` no longer means "row insert time," so anything treating it as would now measure against the pre-retry enqueue time (which is ultimately the point of this change, but is a breaking change nonetheless).

We do **not** query `created_at` as part of the built-in `delayed:monitor` process, so this should not impact any standard gem installs.
