### PR TITLE
feat(ActiveJob): Sync priority to wrapped job

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -1,6 +1,8 @@
 module Delayed
   module Backend
     module Base
+      HOOKS = %i(before success error after failure).freeze
+
       def self.included(base)
         base.extend ClassMethods
       end
@@ -165,15 +167,9 @@ module Delayed
       end
 
       def hook(name, *args)
+        raise ArgumentError, "Unknown hook: #{name.inspect}" unless HOOKS.include?(name)
+
         if payload_object.respond_to?(name)
-          if name == :enqueue
-            raise ':enqueue hook is no longer supported'
-          end
-
-          if payload_object.is_a?(Delayed::JobWrapper)
-            warn '[DEPRECATION] Job hook methods (`before`, `after`, `success`, etc) are deprecated. Use ActiveJob callbacks instead.'
-          end
-
           method = payload_object.method(name)
           method.arity.zero? ? method.call : method.call(self, *args)
         end

--- a/lib/delayed/job_wrapper.rb
+++ b/lib/delayed/job_wrapper.rb
@@ -1,5 +1,17 @@
 module Delayed
   class JobWrapper # rubocop:disable Betterment/ActiveJobPerformable
+    module HookDeprecation
+      Delayed::Backend::Base::HOOKS.each do |hook|
+        define_method(hook) do |*args|
+          if respond_to_missing?(hook, false)
+            warn "[DEPRECATION] Job hook methods (`#{hook}`) are deprecated. Use ActiveJob callbacks instead."
+            super(*args)
+          end
+        end
+      end
+    end
+    include HookDeprecation
+
     attr_accessor :job_data
 
     delegate_missing_to :job
@@ -36,6 +48,12 @@ module Delayed
       rescue NameError
         false
       end
+    end
+
+    def before(record)
+      # ActiveJob retries must know the row's current priority (it may have changed since enqueue).
+      self.priority = record.priority.to_i if respond_to?(:priority=)
+      super
     end
 
     def perform

--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -523,6 +523,15 @@ RSpec.describe Delayed::ActiveJobAdapter do
         expect(retried.priority).to eq(789)
         expect(retried.queue).to eq('fake_queue')
       end
+
+      it 're-enqueues with the current priority of the job row, in case it was updated after enqueue' do
+        MyRetryJob.perform_later('RetryTestError')
+        Delayed::Job.last.update!(priority: 5)
+
+        expect(Delayed::Worker.new.work_off).to eq([1, 0])
+
+        expect(Delayed::Job.last.priority).to eq(5)
+      end
     end
 
     context 'when retry_on specifies a priority' do
@@ -616,6 +625,47 @@ RSpec.describe Delayed::ActiveJobAdapter do
         ActiveJob::Base.execute(MyRetryJob.new('RetryTestError').serialize)
 
         expect(MyRetryJob.queue_adapter.enqueued_jobs.first).to include(job: MyRetryJob, 'priority' => 567)
+      end
+    end
+  end
+
+  describe 'legacy job hooks' do
+    let(:job_class) do
+      Class.new(ActiveJob::Base) do # rubocop:disable Rails/ApplicationJob
+        cattr_accessor(:messages) { [] }
+
+        def perform
+          self.class.messages << 'perform'
+        end
+
+        def before(_delayed_job)
+          self.class.messages << 'before'
+        end
+      end
+    end
+
+    it 'invokes hooks defined on the job class, with a deprecation warning' do
+      JobClass.perform_later
+      delayed_job = enqueued_delayed_jobs.last
+
+      expect { delayed_job.invoke_job }
+        .to output(/\[DEPRECATION\] Job hook methods .* are deprecated\. Use ActiveJob callbacks instead\./).to_stderr
+
+      expect(JobClass.messages).to eq(%w(before perform))
+    end
+
+    context 'when the job class does not define any hook methods' do
+      let(:job_class) do
+        Class.new(ActiveJob::Base) do # rubocop:disable Rails/ApplicationJob
+          def perform; end
+        end
+      end
+
+      it 'does not emit a deprecation warning' do
+        JobClass.perform_later
+        delayed_job = enqueued_delayed_jobs.last
+
+        expect { delayed_job.invoke_job }.not_to output.to_stderr
       end
     end
   end

--- a/spec/delayed/job_spec.rb
+++ b/spec/delayed/job_spec.rb
@@ -349,8 +349,25 @@ describe Delayed::Job do
         job = described_class.new(payload_object: JobWithEnqueueHook.new)
         expect(job.payload_object).not_to receive(:enqueue)
         expect { job.hook(:enqueue) }
-          .to raise_error(RuntimeError, ':enqueue hook is no longer supported')
+          .to raise_error(ArgumentError, 'Unknown hook: :enqueue')
       end
+    end
+  end
+
+  describe '#invoke_job' do
+    it "does not clobber a priority attribute on the object receiving a delayed message" do
+      stub_const('PrioritizedThing', Class.new do
+        attr_accessor :priority
+
+        def check_in; end
+      end)
+      thing = PrioritizedThing.new
+      thing.priority = :domain_specific_value
+
+      job = thing.delay(priority: 3).check_in
+      job.invoke_job
+
+      expect(thing.priority).to eq(:domain_specific_value)
     end
   end
 


### PR DESCRIPTION
The job row's priority may have changed since the job was first enqueued (e.g. bumped by an operator), so this applies that change the next time the job executes.

In practice, this will ensure that `retry_on` and `retry_job` will retry with the priority of the row itself, not the priority the job was originally enqueued with.
