### PR TITLE
feat(ActiveJob): Un-failing resets execution log

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,25 @@ ActiveJob also supports the following lifecycle hooks:
 **Read more about ActiveJob usage on the [Active Job
 Basics](https://guides.rubyonrails.org/active_job_basics.html) documentation page.**
 
+#### Retries: `retry_on` vs. `max_attempts`
+
+ActiveJob and `delayed` each provide their own retry mechanisms, which can be used
+together or independently:
+
+- **`retry_on`** is ActiveJob's retry policy. Matching errors are caught by the job
+  itself and re-enqueued as new jobs, without triggering any of `delayed`'s backstop
+  behaviors (such as incrementing `attempts` or marking the job as failed). This is
+  useful for handling transient/expected errors and can be monitored via the
+  `enqueue_retry.active_job` ActiveSupport::Notification event. (See [ActiveJob's
+  documentation](https://guides.rubyonrails.org/v6.1/active_support_instrumentation.html#active-job)
+  for more details.)
+- **`max_attempts`** (25 by default) is `delayed`'s backstop. Any error that escapes
+  the ActiveJob layer without explicit handling will be caught by `delayed`,
+  incrementing the job's `attempts` counter and triggering all other
+  `delayed`-specific behaviors (like exponential backoff, metrics/alerting, and
+  eventual failure). These errors should be treated as unexpected/unhandled, and may
+  indicate a code bug or data issue that needs to be resolved before the job can
+  succeed.
 
 ## Operational Considerations
 
@@ -270,6 +289,9 @@ corner cases more gracefully (perhaps by no-opping). When you're ready to re-run
 ```ruby
 Delayed::Job.find(failing_job_id).update!(failed_at: nil, attempts: 0, run_at: Time.zone.now)
 ```
+
+For ActiveJob-based jobs, resetting `attempts` to 0 will also restore the job's original
+`retry_on` budgets, allowing any exhausted retries to start over.
 
 ## Monitoring Jobs & Workers
 

--- a/lib/delayed/job_wrapper.rb
+++ b/lib/delayed/job_wrapper.rb
@@ -51,8 +51,17 @@ module Delayed
     end
 
     def before(record)
-      # ActiveJob retries must know the row's current priority (it may have changed since enqueue).
+      # ActiveJob retries should use the row's current priority (it may have changed since enqueue):
       self.priority = record.priority.to_i if respond_to?(:priority=)
+      # If a job is manually reset, we reset ActiveJob's execution log as well:
+      reset_execution_log! if job_data.delete('terminated_at') && record.attempts.zero?
+      super
+    end
+
+    def error(record, error)
+      # The error escaped retry_on (if any), so ActiveJob considers the job terminated.
+      job_data['terminated_at'] = record.class.db_time_now.utc.iso8601(9)
+      record.payload_object = self # re-serialize the handler
       super
     end
 
@@ -67,6 +76,13 @@ module Delayed
     end
 
     private
+
+    def reset_execution_log!
+      job_data['executions'] = 0
+      job_data['exception_executions'] = {}
+      self.executions = job_data['executions'] if respond_to?(:executions=)
+      self.exception_executions = job_data['exception_executions'] if respond_to?(:exception_executions=)
+    end
 
     def job
       @job ||= ActiveJob::Base.deserialize(job_data) if job_data

--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -567,7 +567,7 @@ RSpec.describe Delayed::ActiveJobAdapter do
     end
 
     context 'when attempts are exhausted' do
-      it 're-raises the error, leaving the job to be retried by the worker itself' do
+      it 're-raises the error, marking the ActiveJob as terminated and leaving the job to be retried by the worker itself' do
         job = MyRetryJob.new('RetryTestError')
         job.exception_executions = { '[RetryTestError]' => 4 } # retry_on defaults to 5 attempts
         job.enqueue
@@ -580,7 +580,55 @@ RSpec.describe Delayed::ActiveJobAdapter do
           expect(dj.id).to eq(original.id)
           expect(dj.attempts).to eq(1)
           expect(dj.last_error).to match(/RetryTestError/)
-          expect(dj.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 4)
+          expect(dj.payload_object.job_data['terminated_at']).to be_present
+          expect(dj.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 5)
+        end
+      end
+
+      context 'when the worker then exhausts its own attempts and permanently fails the job' do
+        before do
+          Delayed::Worker.max_attempts = 1
+        end
+
+        it 'resets execution attempts if (and only if) the row attempts is set back to 0' do
+          MyRetryJob.new('RetryTestError').tap do |job|
+            job.executions = 4
+            job.exception_executions = { '[RetryTestError]' => 4 }
+            job.enqueue
+          end
+
+          expect(Delayed::Worker.new.work_off).to eq([0, 1])
+
+          Delayed::Job.last.tap do |dj|
+            expect(dj.failed_at).to be_present
+            expect(dj.payload_object.job_data['terminated_at']).to be_present
+            expect(dj.payload_object.job_data['executions']).to eq(4)
+            expect(dj.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 5)
+          end
+
+          # without setting attempts back to 0:
+          Delayed::Job.last.update!(failed_at: nil, locked_at: nil, locked_by: nil)
+
+          expect(Delayed::Worker.new.work_off).to eq([0, 1])
+
+          retried = Delayed::Job.last
+          expect(retried.failed_at).to be_present
+          expect(retried.attempts).to eq(2)
+          expect(retried.payload_object.job_data['terminated_at']).to be_present
+          expect(retried.payload_object.job_data['executions']).to eq(4)
+          expect(retried.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 6)
+
+          # also setting attempts back to 0:
+          Delayed::Job.last.update!(failed_at: nil, attempts: 0, locked_at: nil, locked_by: nil)
+
+          expect(Delayed::Worker.new.work_off).to eq([1, 0])
+
+          retried = Delayed::Job.last
+          expect(retried.failed_at).to be_nil
+          expect(retried.attempts).to eq(0)
+          expect(retried.payload_object.job_data['terminated_at']).to be_nil
+          expect(retried.payload_object.job_data['executions']).to eq(1)
+          expect(retried.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 1)
         end
       end
     end


### PR DESCRIPTION
Previously, when a job's `retry_on` attempts ran out (resulting in a permanently failed job), un-failing that job would only allow for a single attempt, rather than resetting the attempts counter.

For non-ActiveJobs, we can reset `attempts` back to `0`, but ActiveJobs have no equivalent SQL command and can only be reset via reserializing the job handler in Ruby (making this operation somewhat hostile to bulk operations). This PR aims to address that by checking if an ActiveJob was un-failed, and if so then checking if `attempts` was set to zero.

ActiveJob has no persisted concept of a terminal failure state (i.e. this gem's `failed_at` column), so this gem also extends the serialized payload to include a `terminated_at` key, which survives the round trip as we do not need ActiveJob to reserialize this value when we un-fail jobs.
