### PR TITLE
feat(ActiveJob): Fail jobs when retry_on attempts are exhausted

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ together or independently:
   indicate a code bug or data issue that needs to be resolved before the job can
   succeed.
 
+Importantly, `retry_on` always takes precedence over `max_attempts`, and when a
+`retry_on` policy is exhausted, the job will be failed permanently (i.e. `failed_at`).
+
 ## Operational Considerations
 
 `Delayed` has been shaped around Betterment's day-to-day operational needs. In order to benefit from

--- a/lib/delayed/job_wrapper.rb
+++ b/lib/delayed/job_wrapper.rb
@@ -61,7 +61,17 @@ module Delayed
       # The error escaped retry_on (if any), so ActiveJob considers the job terminated.
       job_data['terminated_at'] = record.class.db_time_now.utc.iso8601(9)
       record.payload_object = self # re-serialize the handler
+
+      # If the error escaped ActiveJob's retry_on policy, we stop the Delayed::Job retries as well.
+      @_aj_retry_terminated = rescue_handlers.any? { |name, _| error.is_a?(name.constantize) }
+
       super
+    end
+
+    def max_attempts
+      return 1 if @_aj_retry_terminated
+
+      super if respond_to_missing?(:max_attempts)
     end
 
     def perform

--- a/spec/delayed/active_job_adapter_spec.rb
+++ b/spec/delayed/active_job_adapter_spec.rb
@@ -567,7 +567,7 @@ RSpec.describe Delayed::ActiveJobAdapter do
     end
 
     context 'when attempts are exhausted' do
-      it 're-raises the error, marking the ActiveJob as terminated and leaving the job to be retried by the worker itself' do
+      it 'marks the ActiveJob as terminated and fails the job immediately, halting the worker retry backstop' do
         job = MyRetryJob.new('RetryTestError')
         job.exception_executions = { '[RetryTestError]' => 4 } # retry_on defaults to 5 attempts
         job.enqueue
@@ -579,56 +579,71 @@ RSpec.describe Delayed::ActiveJobAdapter do
         Delayed::Job.last.tap do |dj|
           expect(dj.id).to eq(original.id)
           expect(dj.attempts).to eq(1)
+          expect(dj.failed_at).to be_present
           expect(dj.last_error).to match(/RetryTestError/)
           expect(dj.payload_object.job_data['terminated_at']).to be_present
           expect(dj.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 5)
         end
       end
 
-      context 'when the worker then exhausts its own attempts and permanently fails the job' do
-        before do
-          Delayed::Worker.max_attempts = 1
+      it 'resets execution attempts if (and only if) the row attempts is set back to 0' do
+        MyRetryJob.new('RetryTestError').tap do |job|
+          job.executions = 4
+          job.exception_executions = { '[RetryTestError]' => 4 }
+          job.enqueue
         end
 
-        it 'resets execution attempts if (and only if) the row attempts is set back to 0' do
-          MyRetryJob.new('RetryTestError').tap do |job|
-            job.executions = 4
-            job.exception_executions = { '[RetryTestError]' => 4 }
-            job.enqueue
-          end
+        expect(Delayed::Worker.new.work_off).to eq([0, 1])
 
-          expect(Delayed::Worker.new.work_off).to eq([0, 1])
+        Delayed::Job.last.tap do |dj|
+          expect(dj.failed_at).to be_present
+          expect(dj.payload_object.job_data['terminated_at']).to be_present
+          expect(dj.payload_object.job_data['executions']).to eq(4)
+          expect(dj.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 5)
+        end
 
-          Delayed::Job.last.tap do |dj|
-            expect(dj.failed_at).to be_present
-            expect(dj.payload_object.job_data['terminated_at']).to be_present
-            expect(dj.payload_object.job_data['executions']).to eq(4)
-            expect(dj.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 5)
-          end
+        # without setting attempts back to 0:
+        Delayed::Job.last.update!(failed_at: nil, locked_at: nil, locked_by: nil)
 
-          # without setting attempts back to 0:
-          Delayed::Job.last.update!(failed_at: nil, locked_at: nil, locked_by: nil)
+        expect(Delayed::Worker.new.work_off).to eq([0, 1])
 
-          expect(Delayed::Worker.new.work_off).to eq([0, 1])
+        retried = Delayed::Job.last
+        expect(retried.failed_at).to be_present
+        expect(retried.attempts).to eq(2)
+        expect(retried.payload_object.job_data['terminated_at']).to be_present
+        expect(retried.payload_object.job_data['executions']).to eq(4)
+        expect(retried.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 6)
 
-          retried = Delayed::Job.last
-          expect(retried.failed_at).to be_present
-          expect(retried.attempts).to eq(2)
-          expect(retried.payload_object.job_data['terminated_at']).to be_present
-          expect(retried.payload_object.job_data['executions']).to eq(4)
-          expect(retried.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 6)
+        # also setting attempts back to 0:
+        Delayed::Job.last.update!(failed_at: nil, attempts: 0, locked_at: nil, locked_by: nil)
 
-          # also setting attempts back to 0:
-          Delayed::Job.last.update!(failed_at: nil, attempts: 0, locked_at: nil, locked_by: nil)
+        expect(Delayed::Worker.new.work_off).to eq([1, 0])
 
-          expect(Delayed::Worker.new.work_off).to eq([1, 0])
+        retried = Delayed::Job.last
+        expect(retried.failed_at).to be_nil
+        expect(retried.attempts).to eq(0)
+        expect(retried.payload_object.job_data['terminated_at']).to be_nil
+        expect(retried.payload_object.job_data['executions']).to eq(1)
+        expect(retried.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 1)
+      end
+    end
 
-          retried = Delayed::Job.last
-          expect(retried.failed_at).to be_nil
-          expect(retried.attempts).to eq(0)
-          expect(retried.payload_object.job_data['terminated_at']).to be_nil
-          expect(retried.payload_object.job_data['executions']).to eq(1)
-          expect(retried.payload_object.job_data['exception_executions']).to eq('[RetryTestError]' => 1)
+    context 'when an error is not covered by any retry_on declaration' do
+      before do
+        stub_const('UncoveredTestError', Class.new(StandardError))
+      end
+
+      it 'marks the ActiveJob as terminated but leaves the job to be retried by the worker itself' do
+        MyRetryJob.perform_later('UncoveredTestError')
+
+        expect(Delayed::Worker.new.work_off).to eq([0, 1])
+
+        expect(Delayed::Job.count).to eq(1)
+        Delayed::Job.last.tap do |dj|
+          expect(dj.attempts).to eq(1)
+          expect(dj.failed_at).to be_nil
+          expect(dj.last_error).to match(/UncoveredTestError/)
+          expect(dj.payload_object.job_data['terminated_at']).to be_present
         end
       end
     end


### PR DESCRIPTION
A `retry_on` declaration is an explicit retry budget for the errors it covers, so once its attempts are exhausted, further retries by the worker's own backstop are contrary to the developer's declared policy. Now, when a retry_on budget runs out, the job is immediately marked as failed.

The worker's retry backstop (`max_attempts`, 25 by default) still applies to errors that have no retry_on policy at all, and jobs may still retry for other reasons (including other retry_on declarations with remaining budget).