### PR TITLE
fix(enqueue_all): Reuse any existing connection lease and avoid holding it.

### DIFF
--- a/lib/delayed/backend/base.rb
+++ b/lib/delayed/backend/base.rb
@@ -79,7 +79,7 @@ module Delayed
           jobs.each { |job| job.created_at = job.updated_at = now }
           rows = jobs.map { |job| job.attributes.compact }
           result = insert_all(rows) # rubocop:disable Rails/SkipsModelValidations
-          return unless connection.supports_insert_returning?
+          return unless connection_pool.with_connection(&:supports_insert_returning?)
 
           ids = result.rows.map(&:first)
           jobs.zip(ids) { |job, id| job.id = id }


### PR DESCRIPTION
This was showing up in the form of connections failing to release in between test cases (causing query timeouts).

> If a connection has already been checked out on the current thread, such as via lease_connection or with_connection, that existing connection will be the one yielded and it will not be returned to the pool automatically at the end of the block ([source](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionPool.html#method-i-with_connection)).

As both jobs and requests tend to already have lifecycle hooks that inject `with_connection`, this behavior would largely only impact usages (such as this gem's own test suite) that call this code from outside such a context.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>