### PR TITLE
release: 4.0 - concurrency limiter & ActiveJob improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    delayed (3.2.0)
+    delayed (4.0.0)
       activerecord (>= 6.0)
       concurrent-ruby
 

--- a/lib/delayed/version.rb
+++ b/lib/delayed/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Delayed
-  VERSION = '3.2.0'
+  VERSION = '4.0.0'
 end


### PR DESCRIPTION
In testing the rollout of [the `Delayed::Limit` concurrency limiter](https://github.com/Betterment/delayed/pull/116) feature, we determined that there were several quality-of-life improvements that could be made to this gem's integration with `ActiveJob` (specifically in the usage of the `retry_on` directive).

As such, this release rolls in both #116 and a list of improvements to the way that `JobWrapper` and `JobPreparer` handle the lifecycle across `delayed`'s execution layer and `ActiveJob`'s execution layer:

- https://github.com/Betterment/delayed/pull/119
- https://github.com/Betterment/delayed/pull/120
- https://github.com/Betterment/delayed/pull/121
- https://github.com/Betterment/delayed/pull/122
- https://github.com/Betterment/delayed/pull/123
- https://github.com/Betterment/delayed/pull/124
- https://github.com/Betterment/delayed/pull/127