### PR TITLE
fix: Defer Rails constant references so `require 'delayed'` works standalone

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    delayed (4.0.0)
+    delayed (4.0.1)
       activerecord (>= 6.0)
       benchmark
       concurrent-ruby

--- a/lib/delayed/helpers/migration.rb
+++ b/lib/delayed/helpers/migration.rb
@@ -33,7 +33,6 @@ module Delayed
         end
       end
 
-      # Evaluated lazily so that requiring this file does not require active_record.
       def self.retry_exceptions
         @retry_exceptions ||= [
           ActiveRecord::LockWaitTimeout,

--- a/lib/delayed/helpers/migration.rb
+++ b/lib/delayed/helpers/migration.rb
@@ -33,18 +33,21 @@ module Delayed
         end
       end
 
-      RETRY_EXCEPTIONS = [
-        ActiveRecord::LockWaitTimeout,
-        ActiveRecord::StatementTimeout,
-        (PG::LockNotAvailable if defined?(PG::LockNotAvailable)),
-      ].compact.freeze
+      # Evaluated lazily so that requiring this file does not require active_record.
+      def self.retry_exceptions
+        @retry_exceptions ||= [
+          ActiveRecord::LockWaitTimeout,
+          ActiveRecord::StatementTimeout,
+          (PG::LockNotAvailable if defined?(PG::LockNotAvailable)),
+        ].compact.freeze
+      end
 
       def with_retry_loop(wait_timeout: 5.minutes, **opts)
         with_timeouts(**opts) do
           loop do
             yield
             break
-          rescue *RETRY_EXCEPTIONS => e
+          rescue *Migration.retry_exceptions => e
             raise if Delayed::Job.db_time_now - @migration_start > wait_timeout
 
             Delayed.logger.warn("Index creation failed for #{opts[:name]}: #{e.message}. Retrying...")

--- a/lib/delayed/job_wrapper.rb
+++ b/lib/delayed/job_wrapper.rb
@@ -34,8 +34,7 @@ module Delayed
 
     # If job failed to deserialize, we can't respond to delegated methods.
     # Returning false here prevents instance method checks from blocking job cleanup.
-    # Rails 8.1+ raises ActiveJob::UnknownJobClassError (rails/rails#53770),
-    # which is checked at runtime so that requiring this file does not require active_job.
+    # Rails 8.1+ raises ActiveJob::UnknownJobClassError (rails/rails#53770).
     def respond_to?(*, **)
       super
     rescue NameError => e

--- a/lib/delayed/job_wrapper.rb
+++ b/lib/delayed/job_wrapper.rb
@@ -34,19 +34,14 @@ module Delayed
 
     # If job failed to deserialize, we can't respond to delegated methods.
     # Returning false here prevents instance method checks from blocking job cleanup.
-    # Rails 8.1+ raises ActiveJob::UnknownJobClassError (rails/rails#53770).
-    if Gem::Version.new(ActiveJob.version) >= Gem::Version.new('8.1')
-      def respond_to?(*, **)
-        super
-      rescue ActiveJob::UnknownJobClassError
-        false
-      end
-    else
-      def respond_to?(*, **)
-        super
-      rescue NameError
-        false
-      end
+    # Rails 8.1+ raises ActiveJob::UnknownJobClassError (rails/rails#53770),
+    # which is checked at runtime so that requiring this file does not require active_job.
+    def respond_to?(*, **)
+      super
+    rescue NameError => e
+      raise if defined?(ActiveJob::UnknownJobClassError) && !e.is_a?(ActiveJob::UnknownJobClassError)
+
+      false
     end
 
     def before(record)

--- a/lib/delayed/version.rb
+++ b/lib/delayed/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Delayed
-  VERSION = '4.0.0'
+  VERSION = '4.0.1'
 end

--- a/spec/delayed_spec.rb
+++ b/spec/delayed_spec.rb
@@ -14,7 +14,7 @@ describe Delayed do
         raise 'expected ActiveJob to not be loaded' if defined?(ActiveJob)
 
         require 'active_job'
-        ActiveJob::Base # trigger autoload, firing the on_load(:active_job) hook
+        ActiveJob::Base # fire the on_load(:active_job) hook
 
         raise 'expected DelayedAdapter to be registered' unless defined?(ActiveJob::QueueAdapters::DelayedAdapter)
       RUBY

--- a/spec/delayed_spec.rb
+++ b/spec/delayed_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+describe Delayed do
+  describe "require 'delayed'" do
+    it 'loads standalone, without active_record or active_job pre-required' do
+      script = <<~RUBY
+        raise 'expected ActiveRecord to not be loaded yet' if defined?(ActiveRecord)
+        raise 'expected ActiveJob to not be loaded yet' if defined?(ActiveJob)
+
+        require 'delayed'
+
+        raise 'expected ActiveJob to not be loaded' if defined?(ActiveJob)
+
+        require 'active_job'
+        ActiveJob::Base # trigger autoload, firing the on_load(:active_job) hook
+
+        raise 'expected DelayedAdapter to be registered' unless defined?(ActiveJob::QueueAdapters::DelayedAdapter)
+      RUBY
+
+      lib = File.expand_path('../lib', __dir__)
+      expect(system(RbConfig.ruby, '-I', lib, '-e', script)).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
As of 4.0.0, a bare `require 'delayed'` raises `NameError` unless activerecord (and activejob) are already loaded, which bites tools that require gems in isolation (e.g. tapioca's gem-loading phase):

1. `lib/delayed/helpers/migration.rb` evaluates `RETRY_EXCEPTIONS = [ActiveRecord::LockWaitTimeout, ...]` in the module body, before `lib/delayed.rb` requires `active_record`. Now a lazily memoized `Migration.retry_exceptions` method (the constant was only used internally). Bonus: the `defined?(PG::LockNotAvailable)` check now runs at migration time, so it works even when `pg` loads after `delayed`.
2. `lib/delayed/job_wrapper.rb` calls `ActiveJob.version` at class definition time, but `lib/delayed.rb` never requires `active_job` (integration is deferred via `on_load(:active_job)`). The Rails 8.1 check now happens at rescue time via `defined?(ActiveJob::UnknownJobClassError)`, with unchanged semantics (`UnknownJobClassError` subclasses `NameError`).

Includes a regression spec that requires `delayed` in a subprocess with no frameworks pre-required (the existing suite can't catch this, since `spec/helper.rb` preloads all frameworks). No eager requires added, preserving the gem's lazy-loading design.
