### PR TITLE
chore: test against postgres 18 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             gemfile: gemfiles/rails_6_1.gemfile
     services:
       postgres:
-        image: postgres:15
+        image: postgres:18
         env:
           POSTGRES_USER: runner
           POSTGRES_PASSWORD: postgres

--- a/spec/delayed/__snapshots__/job_spec.rb.snap
+++ b/spec/delayed/__snapshots__/job_spec.rb.snap
@@ -53,8 +53,8 @@ SNAP
 snapshots["generates a postgresql query plan for multiple queues 1"] = <<-SNAP
 Index Scan using idx_delayed_jobs_live on public.delayed_jobs  (cost=...)
   Output: id, priority, attempts, handler, last_error, run_at, locked_at, failed_at, locked_by, queue, created_at, updated_at, name
-  Index Cond: (delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone)
-  Filter: (((delayed_jobs.queue)::text = ANY ('{default,mailers,tracking}'::text[])) AND ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone) OR (((delayed_jobs.locked_by)::text = 'worker1'::text) AND (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone))))
+  Index Cond: ((delayed_jobs.run_at <= '2025-11-10 17:20:13'::timestamp without time zone) AND ((delayed_jobs.queue)::text = ANY ('{default,mailers,tracking}'::text[])))
+  Filter: ((delayed_jobs.locked_at IS NULL) OR (delayed_jobs.locked_at < '2025-11-10 16:59:43'::timestamp without time zone) OR (((delayed_jobs.locked_by)::text = 'worker1'::text) AND (delayed_jobs.locked_at >= '2025-11-10 16:59:43'::timestamp without time zone)))
 SNAP
 
 snapshots["[legacy index] generates the expected postgresql query plan 1"] = <<-SNAP


### PR DESCRIPTION
Bump the CI postgres service from 15 to 18, update the snaspshot to reference pg 18 behavior.